### PR TITLE
fix: directives work accross shadow roots

### DIFF
--- a/app/deno.jsonc
+++ b/app/deno.jsonc
@@ -15,6 +15,6 @@
     "noImplicitOverride": true
   },
   "imports": {
-    "radish": "npm:@radishland/runtime@^0.1.0"
+    // "radish": "npm:@radishland/runtime@^0.1.0"
   }
 }

--- a/app/elements/handlers/handle-events/handle-events.ts
+++ b/app/elements/handlers/handle-events/handle-events.ts
@@ -13,12 +13,11 @@ export class HandleEvents extends HandlerRegistry {
   }
 
   hook1(element: HTMLElement) {
-    const { signal } = this.abortController;
     console.log("adding hook1 on element", element);
 
     element.addEventListener("mouseover", () => {
       console.log("hovering");
-    }, { signal });
+    }, this.abortController);
 
     element.style.color = "red";
   }

--- a/app/elements/my-article/my-article.html
+++ b/app/elements/my-article/my-article.html
@@ -10,6 +10,8 @@
 
   <article>
     <h1><slot name="title"></slot></h1>
+    <h2><slot name="subtitle"></slot></h2>
+    <button @on="click:hi">hi</button>
     <slot></slot>
   </article>
 </template>

--- a/app/elements/my-article/my-article.ts
+++ b/app/elements/my-article/my-article.ts
@@ -1,4 +1,14 @@
-export class MyArticle extends HTMLElement {}
+import { HandlerRegistry } from "radish";
+
+export class MyArticle extends HandlerRegistry {
+  constructor() {
+    super();
+  }
+
+  hi = () => {
+    console.log("hi");
+  };
+}
 
 if (window && !customElements.get("my-article")) {
   customElements.define("my-article", MyArticle);

--- a/app/elements/rad-unknown/rad-unknown.html
+++ b/app/elements/rad-unknown/rad-unknown.html
@@ -3,4 +3,8 @@
     An unknown element is a reusable snippet without an associated custom
     element
   </p>
+  <p>
+    Dynamic binding: <span @text="h2"></span>
+  </p>
+  <button @on="click:say">say</button>
 </template>

--- a/app/routes/@on/index.html
+++ b/app/routes/@on/index.html
@@ -5,7 +5,7 @@
   <handle-events>
     <button
       @on="click:clickHandler, click:logEvent, keydown:handleKey"
-      @use="hook1, hook2"
+      @use="hook1"
     >
       I will emit an event on click and keydown
     </button>

--- a/app/routes/_app.html
+++ b/app/routes/_app.html
@@ -9,7 +9,7 @@
     %radish.head%
 
     <script type="module">
-      import "@radishland/runtime/boot";
+      import "radish/boot";
     </script>
   </head>
   <body>

--- a/app/routes/hydration/handle-hydration.ts
+++ b/app/routes/hydration/handle-hydration.ts
@@ -1,0 +1,32 @@
+import { HandlerRegistry } from "radish";
+
+export class HandleHydration extends HandlerRegistry {
+  div = document.querySelector("div");
+
+  constructor() {
+    super();
+  }
+
+  hello = () => {
+    console.log("hello");
+  };
+
+  add = () => {
+    const button = document.createElement("button");
+    button.innerText = "click";
+    button.setAttribute("on", "click:hello");
+
+    this.div?.appendChild(button);
+  };
+
+  delete = () => {
+    const child = this.div?.lastChild;
+    if (child) {
+      this.div?.removeChild(child);
+    }
+  };
+}
+
+if (window && !customElements.get("handle-hydration")) {
+  customElements.define("handle-hydration", HandleHydration);
+}

--- a/app/routes/hydration/index.html
+++ b/app/routes/hydration/index.html
@@ -1,0 +1,11 @@
+<script type="module">
+  import "/routes/hydration/handle-hydration.js";
+</script>
+
+<handle-hydration>
+  <p>
+    <button @on="click:add">Add</button>
+    <button @on="click:delete">Delete</button>
+  </p>
+  <div></div>
+</handle-hydration>

--- a/app/routes/projection/index.html
+++ b/app/routes/projection/index.html
@@ -1,10 +1,24 @@
-<main>
-  <my-article>
-    <span slot="title">the title</span>
-    <p>the article</p>
-  </my-article>
+<script type="module">
+  import "/elements/my-article/my-article.js";
+  import "/routes/projection/rad-projection.js";
+  import "/routes/projection/rad-page.js";
+</script>
 
-  <p>
-    Testing declarative shadow root slot projection in template elements
-  </p>
-</main>
+<rad-page>
+  <main>
+    <rad-projection>
+      <my-article>
+        <span slot="title">the title</span>
+        <span slot="subtitle">the <span @text="h2"></span></span>
+        <section>
+          <p>the article</p>
+          <rad-unknown></rad-unknown>
+        </section>
+        <p>
+          Testing declarative shadow root slot projection in template elements
+        </p>
+        <button @on="click:toggle">toggle <span @text="h2"></span></button>
+      </my-article>
+    </rad-projection>
+  </main>
+</rad-page>

--- a/app/routes/projection/rad-page.ts
+++ b/app/routes/projection/rad-page.ts
@@ -1,0 +1,8 @@
+import { HandlerRegistry } from "radish";
+
+export class RadPage extends HandlerRegistry {
+}
+
+if (window && !customElements.get("rad-page")) {
+  customElements.define("rad-page", RadPage);
+}

--- a/app/routes/projection/rad-projection.ts
+++ b/app/routes/projection/rad-projection.ts
@@ -1,0 +1,22 @@
+import { HandlerRegistry } from "radish";
+import { signal } from "radish";
+
+export class RadProjection extends HandlerRegistry {
+  h2 = signal("subtitle");
+
+  toggle = () => {
+    this.h2.value = this.h2.value === "subtitle" ? "description" : "subtitle";
+  };
+
+  say = () => {
+    console.log("bonjour");
+  };
+
+  constructor() {
+    super();
+  }
+}
+
+if (window && !customElements.get("rad-projection")) {
+  customElements.define("rad-projection", RadProjection);
+}

--- a/app/scripts/generate.ts
+++ b/app/scripts/generate.ts
@@ -25,13 +25,15 @@ if (args.includes("--manifest")) {
 
   if (args.includes("--importmap")) {
     await generateImportMap(manifest, {
-      install: "@radishland/runtime@^0.1.0/boot",
+      // When using the development runtime version
+      install: "@preact/signals-core",
       transform: (importmap) => {
         return JSON.stringify({
           imports: {
             ...importmap.imports,
             // When using the development runtime version
-            // "radish": "/_radish/runtime/index.js",
+            "radish": "/_radish/runtime/index.js",
+            "radish/boot": "/_radish/runtime/boot.js",
           },
           scopes: importmap.scopes,
         });

--- a/core/src/build.ts
+++ b/core/src/build.ts
@@ -163,15 +163,93 @@ const buildRoute = (
 export const mockGlobals = (): void => {
   // @ts-ignore mock HTMLElement methods on the server to be noop
   globalThis.HTMLElement = class HTMLElement {
-    attachInternals() {}
+    // Event Target
+    addEventListener() {}
+    dispatchEvent() {}
+    removeEventListener() {}
+    // Node
+    appendChild() {}
+    cloneNode() {}
+    compareDocumentPosition() {}
+    contains() {}
+    getRootNode() {}
+    hasChildNodes() {}
+    insertBefore() {}
+    isDefaultNamespace() {}
+    isEqualNode() {}
+    isSameNode() {}
+    lookupNamespaceURI() {}
+    lookupPrefix() {}
+    normalize() {}
+    removeChild() {}
+    replaceChild() {}
+    // Element
+    after() {}
+    animate() {}
+    append() {}
+    attachShadow() {}
+    before() {}
+    checkVisibility() {}
+    closest() {}
+    computedStyleMap() {}
+    getAnimations() {}
+    getAttribute() {}
+    getAttributeNames() {}
+    getAttributeNode() {}
+    getAttributeNodeNS() {}
+    getAttributeNS() {}
+    getBoundingClientRect() {}
+    getClientRects() {}
+    getElementsByClassName() {}
+    getElementsByTagName() {}
+    getElementsByTagNameNS() {}
+    getHTML() {}
+    hasAttribute() {}
+    hasAttributeNS() {}
+    hasAttributes() {}
+    hasPointerCapture() {}
+    insertAdjacentElement() {}
+    insertAdjacentHTML() {}
+    insertAdjacentText() {}
+    matches() {}
+    prepend() {}
     querySelector() {}
+    querySelectorAll() {}
+    releasePointerCapture() {}
+    remove() {}
+    removeAttribute() {}
+    removeAttributeNode() {}
+    removeAttributeNS() {}
+    replaceChildren() {}
+    replaceWith() {}
+    requestFullscreen() {}
+    requestPointerLock() {}
+    scroll() {}
+    scrollBy() {}
+    scrollIntoView() {}
+    scrollTo() {}
+    setAttribute() {}
+    setAttributeNode() {}
+    setAttributeNodeNS() {}
+    setAttributeNS() {}
+    setHTMLUnsafe() {}
+    setPointerCapture() {}
+    toggleAttribute() {}
+    // HTML Element
+    attachInternals() {}
+    blur() {}
+    click() {}
+    focus() {}
+    hidePopover() {}
+    showPopover() {}
+    togglePopover() {}
   };
-  // @ts-ignore no window on the server
-  globalThis.window = undefined;
-  // @ts-ignore no document on the server
+  // @ts-ignore no op document methods on the server
   globalThis.document = {
     querySelector() {},
   };
+  // @ts-ignore no window on the server
+  globalThis.window = undefined;
   // @ts-ignore no customElements on the server
   globalThis.customElements = undefined;
 };

--- a/core/src/build.ts
+++ b/core/src/build.ts
@@ -168,6 +168,10 @@ export const mockGlobals = (): void => {
   };
   // @ts-ignore no window on the server
   globalThis.window = undefined;
+  // @ts-ignore no document on the server
+  globalThis.document = {
+    querySelector() {},
+  };
   // @ts-ignore no customElements on the server
   globalThis.customElements = undefined;
 };

--- a/deno.lock
+++ b/deno.lock
@@ -27,7 +27,6 @@
     "npm:@jspm/generator@^2.5.1": "2.5.1_@babel+core@7.26.9",
     "npm:@jspm/import-map@^1.1.0": "1.1.0",
     "npm:@preact/signals-core@^1.8.0": "1.8.0",
-    "npm:@radishland/runtime@0.1": "0.1.0",
     "npm:@types/node@*": "22.12.0",
     "npm:tsup@^8.4.0": "8.4.0_typescript@5.7.3_esbuild@0.25.0",
     "npm:typescript@^5.7.2": "5.7.3",
@@ -496,12 +495,6 @@
     },
     "@preact/signals-core@1.8.0": {
       "integrity": "sha512-OBvUsRZqNmjzCZXWLxkZfhcgT+Fk8DDcT/8vD6a1xhDemodyy87UJRJfASMuSD8FaAIeGgGm85ydXhm7lr4fyA=="
-    },
-    "@radishland/runtime@0.1.0": {
-      "integrity": "sha512-PUyFJV3jrT2DK/I5BEBK98mzf8U8o6CuBYOemC8DSmGhCwAoCl3WsDbaxTD6fp9SDtU0Zwqo91AC9uxz7fL7Zg==",
-      "dependencies": [
-        "@preact/signals-core"
-      ]
     },
     "@rollup/rollup-android-arm-eabi@4.34.8": {
       "integrity": "sha512-q217OSE8DTp8AFHuNHXo0Y86e1wtlfVrXiAlwkIvGRQv9zbc6mE3sjIVfwI8sYUyNxwOg0j/Vm1RKM04JcWLJw=="
@@ -1412,11 +1405,6 @@
       "jsr:@std/tar@~0.1.5"
     ],
     "members": {
-      "app": {
-        "dependencies": [
-          "npm:@radishland/runtime@0.1"
-        ]
-      },
       "core": {
         "dependencies": [
           "jsr:@fcrozatier/monarch@^2.5.4",

--- a/runtime/deno.json
+++ b/runtime/deno.json
@@ -2,7 +2,8 @@
   "name": "@radish/runtime",
   "version": "0.1.2",
   "tasks": {
-    "check": "deno fmt --check && deno lint && deno check **/*.ts"
+    "check": "deno fmt --check && deno lint && deno check **/*.ts",
+    "build": "pnpm build"
   },
   "fmt": {
     "exclude": ["**/*.md"]

--- a/runtime/src/types.d.ts
+++ b/runtime/src/types.d.ts
@@ -1,40 +1,25 @@
-export type OnRequestDetail = {
+export interface HandleRequestDetail {
+  target: EventTarget;
+  identifier: string;
+}
+
+export interface OnRequestDetail extends HandleRequestDetail {
   type: string;
-  handler: string;
-};
+}
 
-export type UseRequestDetail = {
-  hook: string;
-};
-
-export type AttrRequestDetail = {
+export interface AttrRequestDetail extends HandleRequestDetail {
   attribute: string;
-  identifier: string;
-};
+}
 
-export type PropRequestDetail = {
+export interface PropRequestDetail extends HandleRequestDetail {
   property: string;
-  identifier: string;
-};
+}
 
-export type TextRequestDetail = {
-  identifier: string;
-};
+export type BindableProperty = "checked" | "value";
 
-export type HTMLRequestDetail = {
-  identifier: string;
-};
-
-export type ClassRequestDetail = {
-  identifier: string;
-};
-
-type BindableProperty = "checked" | "value";
-
-export type BindRequestDetail = {
+export interface BindRequestDetail extends HandleRequestDetail {
   property: BindableProperty;
-  identifier: string;
-};
+}
 
 export interface AutonomousCustomElement {
   /**


### PR DESCRIPTION
Directives now work as expected accross shadow roots:

```html
// my-article.html
<template shadowrootmode="open">
  <article><slot></slot></article>
</template>

// index.html
<handle-click>
  <my-article>
    <button @on="click:hi">click</button>
  </my-article>
</handle-click>
``` 

Here the button is projected into the `my-article` shadow root and the `@on` directive is handled by `handle-click` if it implements `hi`
