### PR TITLE
feat: dev importmap resolves from node_modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ It must appear at the top-level of your component
 
 When building your project, an importmap of the runtime dependencies is generated and inlined in the  `head` of the html. This relies on the [importmap](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap) Web Standard.
 
-In dev mode the importmap resolves modules from the node_modules folder, and in production, it resolves modules from the jspm.io CDN by default but is entirely configurable.
+In dev mode the importmap resolves modules from the node_modules folder by default and allows off-line development, and in production it resolves modules from the jspm.io CDN by default. This is entirely configurable.
 
 The importmap is generated in the `_generated` folder, and you can inspect it with the following commands:
 

--- a/README.md
+++ b/README.md
@@ -405,30 +405,18 @@ It must appear at the top-level of your component
 
 When building your project, an importmap of the runtime dependencies is generated and inlined in the  `head` of the html. This relies on the [importmap](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap) Web Standard.
 
-You have full control over the importmap generation, which is configurable in the `scripts/generate.ts` file:
+In dev mode the importmap resolves modules from the node_modules folder, and in production, it resolves modules from the jspm.io CDN by default but is entirely configurable.
+
+The importmap is generated in the `_generated` folder, and you can inspect it with the following commands:
+
+- `deno task generate --importmap --dev` generated the dev importmap
+- `deno task generate --importmap` generated the production importmap
+
+You have full control over the importmap generation in the `scripts/generate.ts` file:
+
 - a `transform(importmap: ImportMap): string` hook allows you to modify the generated importmap before the file is saved on disk.
 - an `install` option lets you force install any package that can't be statically detected.
 - further options (default registry, custom providers etc) can be passed to the jspm generator
-
-Example. We dynamically import `my-package` and want to override a module with a local one:
-
-```ts
-await generateImportMap(manifest, {
-  install: { target: "my-package@^1.2.3", alias: "$my-lib" }, // Force a package in the importmap
-  transform: (importmap) => {
-    return JSON.stringify({
-      imports: {
-        ...importmap.imports,
-        "mod": "/mod.js", // Override `mod` resolution
-      },
-      scopes: importmap.scopes,
-    });
-  },
-});
-```
-
-> [!NOTE]
-> Most of the time the automatic generation should be enough and you won't have to edit this file too often.
 
 ### No bundle
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,23 +2,22 @@
 
 [x] Inline declarative shadow root templates on the server
 [x] JIT CSS variables: fluid scale and typography
-[x] Hot-reloading dev server
 [x] Scoped Handler Registries
-[x] @on directive (declarative event-handlers)
-[x] @use directive (declarative lifecycle hooks)
+[x] @on directive
+[x] @use directive
 [x] @attr directive
 [x] @class directive
 [x] @prop directive
 [x] @text directive
 [x] @html directive
-[x] @set directive (declarative assignments)
-[x] @bind directive (with resumable state & focus)
-[x] scaffolding scripts for project & components
-[x] auto-generate client importmap
-[x] Auto-load library itself
+[x] @bind directive
+[x] Generate client importmap
+[x] Hydration script
+[x] auto-import custom elements
 
+[ ] Hot-reloading dev server
+[ ] Scaffolding scripts for project & components
 [ ] Lazy load islands
-[ ] auto-import modules of needed custom elements
 [ ] Handle client errors and try-catch components
 [ ] Load effect
 [ ] Option to prerender a component
@@ -26,6 +25,7 @@
 [ ] local first compatible data loading model with storage providers, diffing & merging and smart updates on navigation request
 [?] Convenience: use proxy for state?
 [ ] Distinguish between route level handler registries and others: a global handler throws if it sees an unhandled interaction request
+[ ] Stateful navigation
 
 [ ] Templating: loops
 

--- a/app/deno.jsonc
+++ b/app/deno.jsonc
@@ -16,5 +16,6 @@
   },
   "imports": {
     // "radish": "npm:@radishland/runtime@^0.1.0"
+    "ts-helpers": "npm:@fcrozatier/ts-helpers@^2.8.0"
   }
 }

--- a/app/routes/importmap/handle-input.ts
+++ b/app/routes/importmap/handle-input.ts
@@ -1,0 +1,22 @@
+import { computed, HandlerRegistry } from "radish";
+import { signal } from "radish";
+import { round } from "ts-helpers/numbers";
+
+export class HandleInput extends HandlerRegistry {
+  importmap = signal("");
+  number = signal(0);
+  rounded = computed(() => round(this.number.value, 1));
+
+  override connectedCallback() {
+    super.connectedCallback();
+
+    this.importmap.value =
+      document.querySelector<HTMLScriptElement>("script[type='importmap']")
+        ?.textContent ??
+        "";
+  }
+}
+
+if (window && !customElements.get("handle-input")) {
+  customElements.define("handle-input", HandleInput);
+}

--- a/app/routes/importmap/index.html
+++ b/app/routes/importmap/index.html
@@ -1,0 +1,33 @@
+<radish:head>
+  <title>The importmap</title>
+</radish:head>
+
+<handle-input>
+  <label>
+    number
+    <input type="number" step="0.01" @bind:value="number">
+  </label>
+
+  <p>rounded value: <output @text="rounded"></output></p>
+
+  <p>
+    For the sake of the example, here we use a helper library to round a number
+    to 1 decimal place
+  </p>
+
+  <p>
+    In dev mode the importmap resolves modules from the node_modules folder, in
+    production, it resolves modules from CDNs
+  </p>
+
+  <p>
+    To generate the importmap in dev mode run:
+    <code>deno task generate --importmap --dev</code>
+  </p>
+  <p>
+    To generate the importmap in prod mode run:
+    <code>deno task generate --importmap --prod</code>
+  </p>
+
+  <pre @text="importmap"></pre>
+</handle-input>

--- a/app/routes/importmap/index.html
+++ b/app/routes/importmap/index.html
@@ -26,7 +26,7 @@
   </p>
   <p>
     To generate the importmap in prod mode run:
-    <code>deno task generate --importmap --prod</code>
+    <code>deno task generate --importmap</code>
   </p>
 
   <pre @text="importmap"></pre>

--- a/app/scripts/generate.ts
+++ b/app/scripts/generate.ts
@@ -8,6 +8,11 @@ import {
 
 const args = Deno.args;
 
+if (args.includes("--dev")) {
+  Deno.env.set("dev", "");
+  console.log(`Running in dev mode`);
+}
+
 if (args.includes("--manifest")) {
   generateManifest({
     transform: (content) => {
@@ -41,7 +46,6 @@ if (args.includes("--manifest")) {
     });
   } else if (args.includes("--build")) {
     await build(manifest, {
-      dev: false,
       // speculationRules: {
       //   prerender: [{
       //     where: {

--- a/app/start.ts
+++ b/app/start.ts
@@ -2,4 +2,8 @@ import { start } from "@radish/core";
 
 const dev = Deno.args.includes("--dev");
 
-await start({ dev, router: { matchers: { number: /\d+/ } } });
+if (dev) {
+  Deno.env.set("dev", "");
+}
+
+await start({ router: { matchers: { number: /\d+/ } } });

--- a/core/deno.json
+++ b/core/deno.json
@@ -16,7 +16,8 @@
   "exports": {
     ".": "./exports/mod.ts",
     "./parser": "./exports/parser.ts",
-    "./utils": "./src/utils.ts"
+    "./utils": "./src/utils.ts",
+    "./env": "./src/env.ts"
   },
   "fmt": {
     "exclude": ["**/*.md"]

--- a/core/src/build.ts
+++ b/core/src/build.ts
@@ -13,11 +13,11 @@ import type {
   RouteManifest,
 } from "./generate/manifest.ts";
 import { manifest, sortComponents } from "./generate/manifest.ts";
-import { dev } from "./start.ts";
 import { stripTypes } from "./transforms.ts";
 import type { Transform } from "./types.d.ts";
 import { applyServerEffects, serializeWebComponent } from "./walk.ts";
 import type { SpeculationRules } from "./generate/speculationrules.ts";
+import { dev } from "$env";
 
 const cssTransforms: Transform[] = [];
 const htmlTransforms: Transform[] = [];
@@ -120,7 +120,6 @@ const buildRoute = (
   options: {
     appContent: string;
     importmapContent: string;
-    dev: boolean;
     speculationRules?: SpeculationRules;
   },
 ) => {
@@ -156,7 +155,7 @@ const buildRoute = (
     `;
   }
   // Insert WebSocket script
-  if (options.dev) {
+  if (dev()) {
     pageHeadContent += `
         <script>
           const ws = new WebSocket("ws://localhost:1235/ws");
@@ -194,14 +193,14 @@ const buildRoute = (
       .filter((node) => !!node).flat();
 
     pageHeadContent += serializeFragments(head, {
-      removeComments: !dev,
+      removeComments: !dev(),
     });
   }
 
   let pageBodyContent = "";
   if (pageGroups.body) {
     pageBodyContent = serializeFragments(pageGroups.body, {
-      removeComments: !dev,
+      removeComments: !dev(),
     });
   }
 
@@ -308,10 +307,6 @@ export const mockGlobals = (): void => {
 
 type BuildOptions = {
   /**
-   * Whether to build in dev mode
-   */
-  dev?: boolean;
-  /**
    * The speculation rules of the whole site
    *
    * https://github.com/WICG/nav-speculation/blob/main/triggers.md
@@ -354,7 +349,6 @@ export const build = async (
       buildRoute(component, {
         appContent,
         importmapContent,
-        dev: options?.dev ?? false,
         speculationRules: options?.speculationRules,
       });
     }

--- a/core/src/env.ts
+++ b/core/src/env.ts
@@ -34,3 +34,8 @@ export const loadEnv = () => {
 export const getEnv = (key: string) => {
   return Deno.env.get(key);
 };
+
+/**
+ * Whether the app is running in dev mode
+ */
+export const dev = (): boolean => Deno.env.get("dev") !== undefined;

--- a/core/src/generate/impormap.ts
+++ b/core/src/generate/impormap.ts
@@ -4,16 +4,13 @@ import {
   type Install,
 } from "@jspm/generator";
 import type { IImportMap } from "@jspm/import-map";
+import { dev } from "$env";
 import { join } from "@std/path";
 import { readDenoConfig } from "../config.ts";
 import { generatedFolder } from "../conventions.ts";
 import type { Manifest } from "./manifest.ts";
 
 interface ImportMapOptions {
-  /**
-   * Whether to generate the dev importmap
-   */
-  dev?: boolean;
   /**
    * Manually add a package target into the import map, including all its dependency resolutions via tracing
    */
@@ -45,7 +42,6 @@ export const pureImportMap = async (
   denoImports: Record<string, string>,
   options?: ImportMapOptions,
 ): Promise<IImportMap> => {
-  const { dev, generatorOptions } = { ...options, dev: false };
   const projectImports = new Set<string>();
 
   // Collect deduped import specifiers
@@ -76,15 +72,15 @@ export const pureImportMap = async (
   }
 
   const generator = new Generator({
-    defaultProvider: "jspm.io",
+    defaultProvider: dev() ? "nodemodules" : "jspm.io",
     env: [
-      dev ? "development" : "production",
+      dev() ? "development" : "production",
       "browser",
       "module",
       "import",
       "default",
     ],
-    ...generatorOptions,
+    ...options?.generatorOptions,
   });
 
   // For relative imports and https: targets

--- a/deno.lock
+++ b/deno.lock
@@ -20,6 +20,7 @@
     "jsr:@std/path@^1.0.8": "1.0.8",
     "jsr:@std/streams@^1.0.9": "1.0.9",
     "jsr:@std/tar@~0.1.5": "0.1.5",
+    "npm:@fcrozatier/ts-helpers@^2.8.0": "2.8.0",
     "npm:@jspm/generator@^2.5.1": "2.5.1_@babel+core@7.26.9",
     "npm:@jspm/import-map@^1.1.0": "1.1.0",
     "npm:@preact/signals-core@^1.8.0": "1.8.0",
@@ -411,6 +412,9 @@
     },
     "@esbuild/win32-x64@0.25.0": {
       "integrity": "sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ=="
+    },
+    "@fcrozatier/ts-helpers@2.8.0": {
+      "integrity": "sha512-MyO4gVOkGbxPaa03trLkE5j2Of3oHKWEBGEt9nhurvQofAFGtWTzrFmcaOh0iWxLHswouDfIa62U81V/KG8Z2g=="
     },
     "@gar/promisify@1.1.3": {
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="
@@ -1364,6 +1368,11 @@
       "jsr:@std/tar@~0.1.5"
     ],
     "members": {
+      "app": {
+        "dependencies": [
+          "npm:@fcrozatier/ts-helpers@^2.8.0"
+        ]
+      },
       "core": {
         "dependencies": [
           "jsr:@fcrozatier/type-strip@^1.2.0",

--- a/init/template/base/scripts/generate.ts
+++ b/init/template/base/scripts/generate.ts
@@ -8,6 +8,11 @@ import {
 
 const args = Deno.args;
 
+if (args.includes("--dev")) {
+  Deno.env.set("dev", "");
+  console.log(`Running in dev mode`);
+}
+
 if (args.includes("--manifest")) {
   generateManifest();
 } else {
@@ -22,7 +27,6 @@ if (args.includes("--manifest")) {
     });
   } else if (args.includes("--build")) {
     await build(manifest, {
-      dev: false,
       speculationRules: {
         prerender: [{
           where: {

--- a/init/template/base/start.ts
+++ b/init/template/base/start.ts
@@ -2,4 +2,8 @@ import { start } from "$core";
 
 const dev = Deno.args.includes("--dev");
 
-await start({ dev });
+if (dev) {
+  Deno.env.set("dev", "");
+}
+
+await start();


### PR DESCRIPTION
This allows the importmap to resolve modules from the node_modules in dev mode by default and allows off-line development. This is configurable and the `deno generate --importmap` generates the prod importmap (`--dev` for dev)