### PR TITLE
feat: make node_modules root path configurable

### DIFF
--- a/app/start.ts
+++ b/app/start.ts
@@ -6,4 +6,6 @@ if (dev) {
   Deno.env.set("dev", "");
 }
 
-await start({ router: { matchers: { number: /\d+/ } } });
+await start({
+  router: { matchers: { number: /\d+/ }, nodeModulesRoot: ".." },
+});

--- a/core/src/start.ts
+++ b/core/src/start.ts
@@ -27,7 +27,25 @@ const handle: Handle = async ({ context, resolve }) => {
 
 type StartOptions = {
   router?: {
-    matchers: Record<string, RegExp>;
+    /**
+     * An object mapping matcher names to their corresponding regexp definition.
+     *
+     * Matchers allow to filter dynamic routes like `[id=number]` with a "number" matcher.
+     * For example:
+     *
+     * ```ts
+     * matchers: {
+     *  number: /^\d+$/
+     * }
+     * ```
+     */
+    matchers?: Record<string, RegExp>;
+    /**
+     * Specifies the location of the node_modules folder relative to the deno.json file to serve local dependencies from in dev mode, like `.` or `..` etc.
+     *
+     * @default `.`
+     */
+    nodeModulesRoot?: string;
   };
 };
 
@@ -58,7 +76,9 @@ export const start = async (options?: StartOptions): Promise<void> => {
   router.serveStatic({ pathname: `/${staticFolder}/*` });
 
   if (dev()) {
-    router.serveStatic({ pathname: `/node_modules/*` }, { fsRoot: ".." });
+    router.serveStatic({ pathname: `/node_modules/*` }, {
+      fsRoot: join(options?.router?.nodeModulesRoot ?? "."),
+    });
   }
 
   await router.generateFileBasedRoutes();

--- a/deno.json
+++ b/deno.json
@@ -23,6 +23,7 @@
   "nodeModulesDir": "auto",
   "imports": {
     "$env": "./src/env.ts",
+    "@preact/signals-core": "npm:@preact/signals-core@^1.8.0",
     "radish": "./runtime/src/index.ts",
 
     "@std/assert": "jsr:@std/assert@^1.0.11",

--- a/deno.lock
+++ b/deno.lock
@@ -1462,7 +1462,8 @@
       "jsr:@std/http@^1.0.13",
       "jsr:@std/jsonc@^1.0.1",
       "jsr:@std/path@^1.0.8",
-      "jsr:@std/tar@~0.1.5"
+      "jsr:@std/tar@~0.1.5",
+      "npm:@preact/signals-core@^1.8.0"
     ],
     "members": {
       "app": {

--- a/notebook.ipynb
+++ b/notebook.ipynb
@@ -1,0 +1,40 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[32m\"../node_modules\"\u001b[39m"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Deno",
+   "language": "typescript",
+   "name": "deno"
+  },
+  "language_info": {
+   "codemirror_mode": "typescript",
+   "file_extension": ".ts",
+   "mimetype": "text/x.typescript",
+   "name": "typescript",
+   "nbconvert_exporter": "script",
+   "pygments_lexer": "typescript",
+   "version": "5.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This allows to specify in the start config where the node_modules folder is relative to the deno config file