### PR TITLE
chore(core): use asserts to explicit assumptions

### DIFF
--- a/core/src/env.ts
+++ b/core/src/env.ts
@@ -38,6 +38,6 @@ export const getEnv = (key: string) => {
 /**
  * Whether the app is running in dev mode
  */
-export function dev() {
+export function dev(): boolean {
   return Deno.args.includes("--dev");
 }

--- a/core/src/server/app.ts
+++ b/core/src/server/app.ts
@@ -1,4 +1,5 @@
 import { dev } from "$env";
+import { assertExists } from "@std/assert";
 import { getCookies } from "@std/http/cookie";
 import { extname, isAbsolute, join, relative } from "@std/path";
 import {
@@ -9,8 +10,8 @@ import {
   staticFolder,
 } from "../constants.ts";
 import type { Builder } from "../generate/build.ts";
-import type { ManifestController } from "../generate/manifest.ts";
 import type { ImportMapController } from "../generate/impormap.ts";
+import type { ManifestController } from "../generate/manifest.ts";
 import type {
   HmrContext,
   HmrEvent,
@@ -363,8 +364,9 @@ export class App {
     console.log("HRM server watching...");
 
     const hmr = new Hmr(this);
+    assertExists(this.watcher);
 
-    for await (const event of this.watcher!) {
+    for await (const event of this.watcher) {
       console.log(`FS Event`, event.kind, event.paths, Date.now());
 
       for (const path of event.paths) {

--- a/core/src/types.d.ts
+++ b/core/src/types.d.ts
@@ -54,7 +54,7 @@ export interface TransformContext {
   meta?: { [plugin: string]: any } | null;
 }
 
-export type BuildOptions = {};
+export type BuildOptions = Record<string, any>;
 
 export type HmrEvent = {
   /**

--- a/core/src/utils.ts
+++ b/core/src/utils.ts
@@ -1,9 +1,10 @@
+import { assert } from "@std/assert";
 import { basename } from "@std/path/basename";
 
 /**
  * Generic memoize decorator for a function with no arguments
  */
-export const memoize = <T>(fn: () => T): () => T => {
+export const memoize = <T>(fn: () => T) => {
   let computed = false;
   let result: T;
 
@@ -19,8 +20,11 @@ export const memoize = <T>(fn: () => T): () => T => {
 /**
  * Returns the file name without the extension
  */
-export const fileName = (path: string): string => {
-  return basename(path).split(".")[0]!;
+export const fileName = (path: string) => {
+  const name = basename(path).split(".")[0];
+  assert(!!name, `Expected ${path} filename to not be falsy`);
+
+  return name;
 };
 
 export const setTimeoutWithAbort = (
@@ -46,7 +50,7 @@ export const setTimeoutWithAbort = (
  */
 export function* concatIterators<T>(
   ...iterators: Iterable<T>[]
-): IterableIterator<T> {
+) {
   for (const iterator of iterators) {
     yield* iterator;
   }

--- a/core/src/utils.ts
+++ b/core/src/utils.ts
@@ -4,7 +4,7 @@ import { basename } from "@std/path/basename";
 /**
  * Generic memoize decorator for a function with no arguments
  */
-export const memoize = <T>(fn: () => T) => {
+export const memoize = <T>(fn: () => T): () => T => {
   let computed = false;
   let result: T;
 
@@ -20,12 +20,12 @@ export const memoize = <T>(fn: () => T) => {
 /**
  * Returns the file name without the extension
  */
-export const fileName = (path: string) => {
+export function fileName(path: string): string {
   const name = basename(path).split(".")[0];
   assert(!!name, `Expected ${path} filename to not be falsy`);
 
   return name;
-};
+}
 
 export const setTimeoutWithAbort = (
   handler: () => void,
@@ -44,79 +44,3 @@ export const setTimeoutWithAbort = (
     clearTimeout(id);
   });
 };
-
-/**
- * Concatenates many iterators into a single one
- */
-export function* concatIterators<T>(
-  ...iterators: Iterable<T>[]
-) {
-  for (const iterator of iterators) {
-    yield* iterator;
-  }
-}
-
-type LooseAutocomplete<T extends string> = T | Omit<string, T>;
-
-type Types = LooseAutocomplete<
-  | "null"
-  | "undefined"
-  | "boolean"
-  | "number"
-  | "bigint"
-  | "string"
-  | "symbol"
-  | "function"
-  | "class"
-  | "array"
-  | "date"
-  | "error"
-  | "regexp"
-  | "object"
->;
-
-/**
- * A more reliable `type` function
- */
-export function type(value: unknown): Types {
-  if (value === null) {
-    return "null";
-  }
-
-  if (value === undefined) {
-    return "undefined";
-  }
-
-  const baseType = typeof value;
-  // Primitive types
-  if (!["object", "function"].includes(baseType)) {
-    return baseType;
-  }
-
-  // `Symbol.toStringTag` often specifies the "display name" of the
-  // object's class. It's used in `Object.prototype.toString()`.
-  // @ts-expect-error it's fine if there is no `Symbol.toStringTag`
-  const tag = value[Symbol.toStringTag];
-  if (typeof tag === "string") {
-    return tag;
-  }
-
-  // If it's a function whose source code starts with the "class" keyword
-  if (
-    baseType === "function" &&
-    Function.prototype.toString.call(value).startsWith("class")
-  ) {
-    return "class";
-  }
-
-  // The name of the constructor; for example `Array`, `GeneratorFunction`,
-  // `Number`, `String`, `Boolean` or `MyCustomClass`
-  const className = value.constructor.name;
-  if (typeof className === "string" && className !== "") {
-    return className.toLowerCase();
-  }
-
-  // At this point there's no robust way to get the type of value,
-  // so we use the base implementation.
-  return baseType;
-}

--- a/core/src/utils.ts
+++ b/core/src/utils.ts
@@ -93,9 +93,9 @@ export function type(value: unknown): Types {
     return baseType;
   }
 
-  // Symbol.toStringTag often specifies the "display name" of the
-  // object's class. It's used in Object.prototype.toString().
-  // @ts-expect-error
+  // `Symbol.toStringTag` often specifies the "display name" of the
+  // object's class. It's used in `Object.prototype.toString()`.
+  // @ts-expect-error it's fine if there is no `Symbol.toStringTag`
   const tag = value[Symbol.toStringTag];
   if (typeof tag === "string") {
     return tag;

--- a/deno.json
+++ b/deno.json
@@ -19,7 +19,7 @@
         "prefer-ascii",
         "verbatim-module-syntax"
       ],
-      "exclude": ["no-explicit-any"],
+      "exclude": ["no-explicit-any", "ban-types"],
       "tags": ["jsr", "recommended"]
     }
   },

--- a/htmlcrunch/mod.ts
+++ b/htmlcrunch/mod.ts
@@ -15,6 +15,7 @@ import {
   whitespace,
   whitespaces,
 } from "@fcrozatier/monarch/common";
+import { assertExists } from "@std/assert";
 
 /**
  * A comment node
@@ -175,11 +176,14 @@ export const element: Parser<MElement> = createParser((input, position) => {
 
   if (!openTag.success) return openTag;
 
+  const openTagResult = openTag.results[0];
+  assertExists(openTagResult);
+
   const {
     value: { tagName, attributes },
     remaining,
     position: openTagPosition,
-  } = openTag.results[0]!;
+  } = openTagResult;
 
   const kind = elementKind(tagName);
 
@@ -222,18 +226,22 @@ export const element: Parser<MElement> = createParser((input, position) => {
     return childrenElements;
   }
 
+  const childrenElementsResult = childrenElements.results[0];
+  assertExists(childrenElementsResult);
+
   const {
     value: children,
     remaining: childrenRemaining,
     position: childrenPosition,
-  } = childrenElements.results[0]!;
+  } = childrenElementsResult;
 
   const res = endTagParser.parse(childrenRemaining, childrenPosition);
 
   // End tag omission would be managed here
   if (!res.success) return res;
 
-  const result = res.results[0]!;
+  const result = res.results[0];
+  assertExists(result);
 
   return {
     success: true,

--- a/init/mod.ts
+++ b/init/mod.ts
@@ -1,3 +1,4 @@
+import { assert, assertExists } from "@std/assert";
 import { parseArgs } from "@std/cli/parse-args";
 import { Spinner } from "@std/cli/unstable-spinner";
 import { bold, green } from "@std/fmt/colors";
@@ -57,44 +58,52 @@ try {
   spinner.message = "Fetching meta data...";
   const res = await fetch(metaURL);
   const metadata = await res.json() as { manifest: Record<string, any> };
+  assertExists(metadata);
 
-  if (metadata?.manifest) {
-    const pathsByArgs = Object.groupBy(Object.keys(metadata.manifest), (k) => {
-      if (k.startsWith("/template/base/")) return "base";
-      else if (k.startsWith("/template/vscode/")) return "vscode";
-      return "skip";
-    });
+  const pathsByArgs = Object.groupBy(Object.keys(metadata.manifest), (k) => {
+    if (k.startsWith("/template/base/")) return "base";
+    else if (k.startsWith("/template/vscode/")) return "vscode";
+    return "skip";
+  });
 
-    spinner.message = "Fetching template files...";
-    for (
-      const arg of Object.keys(pathsByArgs) as (keyof typeof pathsByArgs)[]
-    ) {
-      switch (arg) {
-        case "skip":
-          continue;
+  spinner.message = "Fetching template files...";
+  for (
+    const arg of Object.keys(pathsByArgs) as (keyof typeof pathsByArgs)[]
+  ) {
+    switch (arg) {
+      case "skip":
+        continue;
 
-        case "vscode":
-          if (!vscode) continue;
-      }
+      case "vscode":
+        if (!vscode) continue;
+    }
 
-      const paths = pathsByArgs[arg]!;
-      const textFiles = await Promise.all(
-        paths.map(async (path) => {
-          const res = await fetch(`${packageUrl}${version}${path}`);
-          return await res.text();
-        }),
+    const paths = pathsByArgs[arg];
+    assertExists(paths);
+
+    const textFiles = await Promise.all(
+      paths.map(async (path) => {
+        const res = await fetch(`${packageUrl}${version}${path}`);
+        return await res.text();
+      }),
+    );
+
+    assert(paths.length === textFiles.length);
+
+    for (let i = 0; i < paths.length; i++) {
+      const path: string | undefined = paths[i];
+      const content = textFiles[i];
+
+      assertExists(path);
+      assertExists(content);
+
+      const dest = join(
+        projectPath,
+        path.replaceAll(new RegExp(`^/template/${arg}/`, "g"), ""),
       );
 
-      for (let i = 0; i < paths.length; i++) {
-        const path = paths[i]!;
-        const dest = join(
-          projectPath,
-          path.replaceAll(new RegExp(`^/template/${arg}/`, "g"), ""),
-        );
-
-        Deno.mkdirSync(dirname(dest), { recursive: true });
-        Deno.writeTextFileSync(dest, textFiles[i]!);
-      }
+      Deno.mkdirSync(dirname(dest), { recursive: true });
+      Deno.writeTextFileSync(dest, content);
     }
   }
 } catch (error) {

--- a/runtime/src/utils.ts
+++ b/runtime/src/utils.ts
@@ -40,7 +40,7 @@ export function type(value: unknown): Types {
 
   // Symbol.toStringTag often specifies the "display name" of the
   // object's class. It's used in Object.prototype.toString().
-  // @ts-expect-error
+  // @ts-expect-error it's fine if there is no `Symbol.toStringTag`
   const tag = value[Symbol.toStringTag];
   if (typeof tag === "string") {
     return tag;


### PR DESCRIPTION
This adds some defensive programming to the code base, by laying out explicit assumptions made about the code with asserts. It will help in the long run to catch bugs early