### PR TITLE
breaking(effect-system): disposable HandlerScope

### DIFF
--- a/app/start.ts
+++ b/app/start.ts
@@ -1,5 +1,6 @@
 import { importmapPath, manifestPath, startApp } from "@radish/core";
-import { handlerFor, importmap, io } from "@radish/core/effects";
+import { handlerFor } from "@radish/effect-system";
+import { importmap, io } from "@radish/core/effects";
 import {
   pluginBuild,
   pluginConfig,

--- a/core/src/plugins/env/env.test.ts
+++ b/core/src/plugins/env/env.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "@std/assert";
 import { config } from "$effects/config.ts";
-import { handlerFor, runWith } from "@radish/effect-system";
+import { handlerFor, HandlerScope } from "@radish/effect-system";
 import { env } from "$effects/env.ts";
 import { io } from "$effects/io.ts";
 import { pluginEnv } from "../env/env.ts";
@@ -54,10 +54,10 @@ export const URL = "https://example.com";
 
 let result: string | undefined;
 
-Deno.test("env plugin", () => {
-  runWith(async () => {
-    await env.load();
+Deno.test("env plugin", async () => {
+  using _ = new HandlerScope([...handlers, ...pluginEnv.handlers]);
 
-    assertEquals(result?.trim(), expected);
-  }, [...handlers, ...pluginEnv.handlers]);
+  await env.load();
+
+  assertEquals(result?.trim(), expected);
 });

--- a/core/src/plugins/env/env.ts
+++ b/core/src/plugins/env/env.ts
@@ -58,20 +58,17 @@ export const pluginEnv: Plugin = {
 
 async function load() {
   const envPath = await getEnvPath();
+  const envFile = await io.readFile(envPath);
+  const envObject = parse(envFile);
+  let envModule = "";
 
-  if (envPath) {
-    const envFile = await io.readFile(envPath);
-    const envObject = parse(envFile);
-    let envModule = "";
-
-    for (const [key, value] of Object.entries(envObject)) {
-      envModule += `export const ${key} = ${parseValue(value)};\n`;
-      if (Deno.env.get(key) !== undefined) continue;
-      Deno.env.set(key, value);
-    }
-
-    await io.writeFile(envModulePath, envModule);
+  for (const [key, value] of Object.entries(envObject)) {
+    envModule += `export const ${key} = ${parseValue(value)};\n`;
+    if (Deno.env.get(key) !== undefined) continue;
+    Deno.env.set(key, value);
   }
+
+  await io.writeFile(envModulePath, envModule);
 }
 
 /**

--- a/core/src/plugins/render/directives/attr/attr.test.ts
+++ b/core/src/plugins/render/directives/attr/attr.test.ts
@@ -3,7 +3,7 @@ import { assertEquals } from "@std/assert";
 import { dirname, fromFileUrl, join } from "@std/path";
 import { describe, test } from "@std/testing/bdd";
 import { globals } from "../../../../constants.ts";
-import { handlerFor, runWith } from "@radish/effect-system";
+import { handlerFor, HandlerScope } from "@radish/effect-system";
 import { io } from "$effects/io.ts";
 import { manifest } from "$effects/manifest.ts";
 import { id } from "../../../../utils/algebraic-structures.ts";
@@ -22,17 +22,7 @@ globals();
 
 describe("attr directive", () => {
   test("renders", async () => {
-    await runWith(async () => {
-      const content = await Deno.readTextFile(join(testDataDir, "input.html"));
-      const output = await Deno.readTextFile(join(testDataDir, "output.html"));
-
-      const { content: transformed } = await io.transformFile({
-        path: "elements/my-component.html",
-        content,
-      });
-
-      assertEquals(transformed, output);
-    }, [
+    using _ = new HandlerScope([
       handleTransformFile,
       handlerFor(io.transformFile, id),
       handleComponents,
@@ -63,5 +53,15 @@ describe("attr directive", () => {
         };
       }),
     ]);
+
+    const content = await Deno.readTextFile(join(testDataDir, "input.html"));
+    const output = await Deno.readTextFile(join(testDataDir, "output.html"));
+
+    const { content: transformed } = await io.transformFile({
+      path: "elements/my-component.html",
+      content,
+    });
+
+    assertEquals(transformed, output);
   });
 });

--- a/core/src/plugins/render/directives/bind/bind.test.ts
+++ b/core/src/plugins/render/directives/bind/bind.test.ts
@@ -3,7 +3,7 @@ import { assertEquals } from "@std/assert";
 import { dirname, fromFileUrl, join } from "@std/path";
 import { describe, test } from "@std/testing/bdd";
 import { globals } from "../../../../constants.ts";
-import { handlerFor, runWith } from "@radish/effect-system";
+import { handlerFor, HandlerScope } from "@radish/effect-system";
 import { io } from "$effects/io.ts";
 import { manifest } from "$effects/manifest.ts";
 import { id } from "../../../../utils/algebraic-structures.ts";
@@ -22,19 +22,7 @@ globals();
 
 describe("bind directive", () => {
   test("renders", async () => {
-    await runWith(async () => {
-      const content = await Deno.readTextFile(join(testDataDir, "input.html"));
-      const output = await Deno.readTextFile(
-        join(testDataDir, "output.html"),
-      );
-
-      const { content: transformed } = await io.transformFile({
-        path: "elements/my-component.html",
-        content,
-      });
-
-      assertEquals(transformed, output);
-    }, [
+    using _ = new HandlerScope([
       handleTransformFile,
       handlerFor(io.transformFile, id),
       handleComponents,
@@ -65,5 +53,17 @@ describe("bind directive", () => {
         };
       }),
     ]);
+
+    const content = await Deno.readTextFile(join(testDataDir, "input.html"));
+    const output = await Deno.readTextFile(
+      join(testDataDir, "output.html"),
+    );
+
+    const { content: transformed } = await io.transformFile({
+      path: "elements/my-component.html",
+      content,
+    });
+
+    assertEquals(transformed, output);
   });
 });

--- a/core/src/plugins/render/directives/bool/bool.test.ts
+++ b/core/src/plugins/render/directives/bool/bool.test.ts
@@ -3,7 +3,7 @@ import { assertEquals } from "@std/assert";
 import { dirname, fromFileUrl, join } from "@std/path";
 import { describe, test } from "@std/testing/bdd";
 import { globals } from "../../../../constants.ts";
-import { handlerFor, runWith } from "@radish/effect-system";
+import { handlerFor, HandlerScope } from "@radish/effect-system";
 import { io } from "$effects/io.ts";
 import { manifest } from "$effects/manifest.ts";
 import { id } from "../../../../utils/algebraic-structures.ts";
@@ -22,19 +22,7 @@ globals();
 
 describe("bool directive", () => {
   test("renders", async () => {
-    await runWith(async () => {
-      const content = await Deno.readTextFile(join(testDataDir, "input.html"));
-      const output = await Deno.readTextFile(
-        join(testDataDir, "output.nofmt.html"),
-      );
-
-      const { content: transformed } = await io.transformFile({
-        path: "elements/my-component.html",
-        content,
-      });
-
-      assertEquals(transformed, output);
-    }, [
+    using _ = new HandlerScope([
       handleTransformFile,
       handlerFor(io.transformFile, id),
       handleComponents,
@@ -65,5 +53,17 @@ describe("bool directive", () => {
         };
       }),
     ]);
+
+    const content = await Deno.readTextFile(join(testDataDir, "input.html"));
+    const output = await Deno.readTextFile(
+      join(testDataDir, "output.nofmt.html"),
+    );
+
+    const { content: transformed } = await io.transformFile({
+      path: "elements/my-component.html",
+      content,
+    });
+
+    assertEquals(transformed, output);
   });
 });

--- a/core/src/plugins/render/directives/classList/classList.test.ts
+++ b/core/src/plugins/render/directives/classList/classList.test.ts
@@ -3,7 +3,7 @@ import { assertEquals } from "@std/assert";
 import { dirname, fromFileUrl, join } from "@std/path";
 import { describe, test } from "@std/testing/bdd";
 import { globals } from "../../../../constants.ts";
-import { handlerFor, runWith } from "@radish/effect-system";
+import { handlerFor, HandlerScope } from "@radish/effect-system";
 import { io } from "$effects/io.ts";
 import { manifest } from "$effects/manifest.ts";
 import { id } from "../../../../utils/algebraic-structures.ts";
@@ -22,19 +22,7 @@ globals();
 
 describe("classList directive", () => {
   test("renders", async () => {
-    await runWith(async () => {
-      const content = await Deno.readTextFile(join(testDataDir, "input.html"));
-      const output = await Deno.readTextFile(
-        join(testDataDir, "output.html"),
-      );
-
-      const { content: transformed } = await io.transformFile({
-        path: "elements/my-component.html",
-        content,
-      });
-
-      assertEquals(transformed, output);
-    }, [
+    using _ = new HandlerScope([
       handleTransformFile,
       handlerFor(io.transformFile, id),
       handleComponents,
@@ -67,5 +55,17 @@ describe("classList directive", () => {
         };
       }),
     ]);
+
+    const content = await Deno.readTextFile(join(testDataDir, "input.html"));
+    const output = await Deno.readTextFile(
+      join(testDataDir, "output.html"),
+    );
+
+    const { content: transformed } = await io.transformFile({
+      path: "elements/my-component.html",
+      content,
+    });
+
+    assertEquals(transformed, output);
   });
 });

--- a/core/src/plugins/render/directives/html/html.test.ts
+++ b/core/src/plugins/render/directives/html/html.test.ts
@@ -3,7 +3,7 @@ import { assertEquals } from "@std/assert";
 import { dirname, fromFileUrl, join } from "@std/path";
 import { describe, test } from "@std/testing/bdd";
 import { globals } from "../../../../constants.ts";
-import { handlerFor, runWith } from "@radish/effect-system";
+import { handlerFor, HandlerScope } from "@radish/effect-system";
 import { io } from "$effects/io.ts";
 import { manifest } from "$effects/manifest.ts";
 import { id } from "../../../../utils/algebraic-structures.ts";
@@ -22,19 +22,7 @@ globals();
 
 describe("html directive", () => {
   test("renders", async () => {
-    await runWith(async () => {
-      const content = await Deno.readTextFile(join(testDataDir, "input.html"));
-      const output = await Deno.readTextFile(
-        join(testDataDir, "output.nofmt.html"),
-      );
-
-      const { content: transformed } = await io.transformFile({
-        path: "elements/my-component.html",
-        content,
-      });
-
-      assertEquals(transformed, output);
-    }, [
+    using _ = new HandlerScope([
       handleTransformFile,
       handlerFor(io.transformFile, id),
       handleComponents,
@@ -67,5 +55,17 @@ describe("html directive", () => {
         };
       }),
     ]);
+
+    const content = await Deno.readTextFile(join(testDataDir, "input.html"));
+    const output = await Deno.readTextFile(
+      join(testDataDir, "output.nofmt.html"),
+    );
+
+    const { content: transformed } = await io.transformFile({
+      path: "elements/my-component.html",
+      content,
+    });
+
+    assertEquals(transformed, output);
   });
 });

--- a/core/src/plugins/render/directives/text/text.test.ts
+++ b/core/src/plugins/render/directives/text/text.test.ts
@@ -3,7 +3,7 @@ import { assertEquals } from "@std/assert";
 import { dirname, fromFileUrl, join } from "@std/path";
 import { describe, test } from "@std/testing/bdd";
 import { globals } from "../../../../constants.ts";
-import { handlerFor, runWith } from "@radish/effect-system";
+import { handlerFor, HandlerScope } from "@radish/effect-system";
 import { io } from "$effects/io.ts";
 import { manifest } from "$effects/manifest.ts";
 import { id } from "../../../../utils/algebraic-structures.ts";
@@ -22,19 +22,7 @@ globals();
 
 describe("text directive", () => {
   test("renders", async () => {
-    await runWith(async () => {
-      const content = await Deno.readTextFile(join(testDataDir, "input.html"));
-      const output = await Deno.readTextFile(
-        join(testDataDir, "output.html"),
-      );
-
-      const { content: transformed } = await io.transformFile({
-        path: "elements/my-component.html",
-        content,
-      });
-
-      assertEquals(transformed, output);
-    }, [
+    using _ = new HandlerScope([
       handleTransformFile,
       handlerFor(io.transformFile, id),
       handleComponents,
@@ -67,5 +55,17 @@ describe("text directive", () => {
         };
       }),
     ]);
+
+    const content = await Deno.readTextFile(join(testDataDir, "input.html"));
+    const output = await Deno.readTextFile(
+      join(testDataDir, "output.html"),
+    );
+
+    const { content: transformed } = await io.transformFile({
+      path: "elements/my-component.html",
+      content,
+    });
+
+    assertEquals(transformed, output);
   });
 });

--- a/core/src/start.ts
+++ b/core/src/start.ts
@@ -38,11 +38,8 @@ export async function startApp(
   config: Config,
   getManifest: () => Promise<any>,
 ) {
-  for (const plugin of config.plugins ?? []) {
-    if (plugin.handlers) {
-      effects.addHandlers(plugin.handlers);
-    }
-  }
+  const handlers = config.plugins?.flatMap((plugin) => plugin.handlers);
+  using _ = new effects.HandlerScope(handlers);
 
   config = await configEffect.transform(config);
 

--- a/core/src/types.d.ts
+++ b/core/src/types.d.ts
@@ -1,7 +1,6 @@
 import type { Handlers } from "@radish/effect-system";
-import type { ImportMapOptions } from "./plugins/importmap/importmap.ts";
 import type { SpeculationRules } from "./generate/speculationrules.ts";
-import type { LoadOptions } from "@std/dotenv";
+import type { ImportMapOptions } from "./plugins/importmap/importmap.ts";
 
 export type MaybePromise<T> = T | Promise<T>;
 
@@ -46,11 +45,11 @@ export interface Plugin {
 export interface Config {
   env?: {
     /**
-     * Path to the env file. Set to `null` to prevent the default value from being used.
+     * Path to the env file.
      *
      * @default ".env"
      */
-    envPath?: LoadOptions["envPath"];
+    envPath?: string;
   };
   importmap?: ImportMapOptions;
   /**

--- a/deno.json
+++ b/deno.json
@@ -47,6 +47,7 @@
     "radish": "./runtime/src/index.ts",
 
     "@std/assert": "jsr:@std/assert@^1.0.13",
+    "@std/async": "jsr:@std/async@^1.0.13",
     "@std/cli": "jsr:@std/cli@^1.0.17",
     "@std/collections": "jsr:@std/collections@^1.0.11",
     "@std/dotenv": "jsr:@std/dotenv@^0.225.3",

--- a/effect-system/handlers.ts
+++ b/effect-system/handlers.ts
@@ -222,15 +222,16 @@ export class HandlerScope {
  * @see {@linkcode addHandlers}
  */
 export const runWith = async <T>(
-  fn: () => Promise<T>,
+  fn: () => MaybePromise<T>,
   handlers: Handlers,
 ): Promise<T> => {
   const currentScope = handlerScopes.at(-1);
   const scope = new HandlerScope(currentScope);
+
+  handlerScopes.push(scope);
   scope.addHandlers(handlers);
 
   try {
-    handlerScopes.push(scope);
     return await fn();
   } finally {
     handlerScopes.pop();

--- a/effect-system/handlers.ts
+++ b/effect-system/handlers.ts
@@ -3,7 +3,7 @@ import { assert } from "@std/assert";
 /**
  * The list of current scopes.
  *
- * You do not interact with it directly. It is managed by {@linkcode runWith}
+ * This is managed automatically by {@linkcode HandlerScope}
  *
  * @internal
  */
@@ -260,40 +260,6 @@ export class HandlerScope {
     handlerScopes.pop();
   }
 }
-
-/**
- * Creates a new {@linkcode HandlerScope} where the passed handlers are registered, and executes the provided effectful program with the handlers in scope
- *
- * The provided handlers are only in scope inside the
- *
- * @example Ordering handlers
- *
- * The ordering of the handlers matters when they rely on delegation via {@linkcode Handler.continue}
- *
- * ```ts
- * import { runWith } from 'radish/effects';
- *
- * runWith(async () => {
- *   const txtFile = await io.read("hello.txt"); // "I can only handle .txt files"
- *   const jsonFile = await io.read("hello.json"); // ...
- * }, [handleTXTOnly, handleReadOp])
- * ```
- *
- * @param fn The effectful program to run
- * @param handlers A list of handlers implementing **all** the effects performed by the program
- *
- * @throws Throws "Unhandled effect" when an effect is performed with no handler in scope
- *
- * @see {@linkcode addHandlers}
- */
-export const runWith = async <T>(
-  fn: () => MaybePromise<T>,
-  handlers: Handlers,
-): Promise<T> => {
-  using _ = new HandlerScope(handlers);
-
-  return await fn();
-};
 
 /**
  * Adds a list of handlers to the current {@linkcode HandlersScope}

--- a/effect-system/mod.ts
+++ b/effect-system/mod.ts
@@ -9,7 +9,7 @@
  *
  * Use {@linkcode createEffect} to define an effect, and {@linkcode handlerFor} to implement a handler.
  *
- * To run effectful code with handlers in scope use {@linkcode runWith}.
+ * To create a new scope with handlers to run effects in {@linkcode HandlerScope}.
  *
  * Handlers can also be added dynamically to a running programming with {@linkcode addHandlers}
  *
@@ -71,7 +71,6 @@ export {
   Handler,
   type Handlers,
   HandlerScope,
-  runWith,
 } from "./handlers.ts";
 
 /**

--- a/effect-system/mod.ts
+++ b/effect-system/mod.ts
@@ -50,16 +50,15 @@
  *
  * @example Running code with effects and handlers
  *
- * {@linkcode runWith} takes an effectful program to run and a list of handlers
+ * {@linkcode HandlerScope} creates a new scope where handlers can handle effects
  *
  * ```ts
- * import { runWith } from "@radish/effect-system";
+ * {
+ *  using _ = new HandlerScope([handleIOTransform]);
  *
- * runWith(async () => {
- *   const transformed: string = await io.transform("some content");
- *   console.log(transformed);
- * }, [handleIOTransform]);
- *
+ *  const transformed = await io.transform("some content");
+ *  console.log(transformed);
+ * }
  * ```
  *
  * @module


### PR DESCRIPTION
Now scopes can be stacked directly without nested callbacks

This remove the need for `runWith` and makes context creation explicit (and managed) with `using _ = new HandlerScope();`

```ts
{
using _ = new HandlerScope(myHandlers);

await myEffect.myOp();
}
```