### PR TITLE
breaking(effect-system): Snapshots, AsyncState and disposable HandlerScopes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,8 @@
         "--allow-all"
       ],
       "env": {},
-      "attachSimplePort": 9229
+      "attachSimplePort": 9229,
+      "experimentalNetworking": "off"
     },
     {
       "name": "deno test",
@@ -35,7 +36,8 @@
         "--no-check"
       ],
       "env": {},
-      "attachSimplePort": 9229
+      "attachSimplePort": 9229,
+      "experimentalNetworking": "off"
     },
     {
       "name": "deno run in app",
@@ -55,7 +57,8 @@
       "env": {},
       // Debug command args: "--build", "--importmap" etc.
       "args": [],
-      "attachSimplePort": 9229
+      "attachSimplePort": 9229,
+      "experimentalNetworking": "off"
     }
   ]
 }

--- a/core/src/plugins/env/env.test.ts
+++ b/core/src/plugins/env/env.test.ts
@@ -55,7 +55,7 @@ export const URL = "https://example.com";
 let result: string | undefined;
 
 Deno.test("env plugin", async () => {
-  using _ = new HandlerScope([...handlers, ...pluginEnv.handlers]);
+  using _ = new HandlerScope(...handlers, ...pluginEnv.handlers);
 
   await env.load();
 

--- a/core/src/plugins/importmap/importmap.test.ts
+++ b/core/src/plugins/importmap/importmap.test.ts
@@ -98,7 +98,7 @@ const moduleDir = dirname(fromFileUrl(import.meta.url));
 
 describe("importmap generation", () => {
   test("transforms index.html files", async () => {
-    using _ = new HandlerScope([
+    using _ = new HandlerScope(
       ...pluginImportmap.handlers,
       handlerFor(io.readFile, async (path) => {
         if (path === importmapPath) {
@@ -109,7 +109,7 @@ describe("importmap generation", () => {
         return "";
       }),
       handlerFor(io.transformFile, id),
-    ]);
+    );
 
     const input = await Deno.readTextFile(
       join(moduleDir, "testdata", "input.html"),

--- a/core/src/plugins/manifest/manifest.test.ts
+++ b/core/src/plugins/manifest/manifest.test.ts
@@ -30,7 +30,7 @@ const createWalkEntry = (path: string): WalkEntry => {
   };
 };
 
-using _ = new HandlerScope([
+using _ = new HandlerScope(
   handlerFor(io.readFile, (path) => {
     const content = files[path];
     assertExists(content);
@@ -74,7 +74,7 @@ using _ = new HandlerScope([
     return Handler.continue({ entry, manifestObject });
   }),
   handlerFor(manifest.update, id),
-]);
+);
 
 for (const path of Object.keys(files)) {
   const { manifestObject: newManifest } = await manifest.update({

--- a/core/src/plugins/render/directives/attr/attr.test.ts
+++ b/core/src/plugins/render/directives/attr/attr.test.ts
@@ -22,7 +22,7 @@ globals();
 
 describe("attr directive", () => {
   test("renders", async () => {
-    using _ = new HandlerScope([
+    using _ = new HandlerScope(
       handleTransformFile,
       handlerFor(io.transformFile, id),
       handleComponents,
@@ -52,7 +52,7 @@ describe("attr directive", () => {
           },
         };
       }),
-    ]);
+    );
 
     const content = await Deno.readTextFile(join(testDataDir, "input.html"));
     const output = await Deno.readTextFile(join(testDataDir, "output.html"));

--- a/core/src/plugins/render/directives/bind/bind.test.ts
+++ b/core/src/plugins/render/directives/bind/bind.test.ts
@@ -22,7 +22,7 @@ globals();
 
 describe("bind directive", () => {
   test("renders", async () => {
-    using _ = new HandlerScope([
+    using _ = new HandlerScope(
       handleTransformFile,
       handlerFor(io.transformFile, id),
       handleComponents,
@@ -52,7 +52,7 @@ describe("bind directive", () => {
           },
         };
       }),
-    ]);
+    );
 
     const content = await Deno.readTextFile(join(testDataDir, "input.html"));
     const output = await Deno.readTextFile(

--- a/core/src/plugins/render/directives/bool/bool.test.ts
+++ b/core/src/plugins/render/directives/bool/bool.test.ts
@@ -22,7 +22,7 @@ globals();
 
 describe("bool directive", () => {
   test("renders", async () => {
-    using _ = new HandlerScope([
+    using _ = new HandlerScope(
       handleTransformFile,
       handlerFor(io.transformFile, id),
       handleComponents,
@@ -52,7 +52,7 @@ describe("bool directive", () => {
           },
         };
       }),
-    ]);
+    );
 
     const content = await Deno.readTextFile(join(testDataDir, "input.html"));
     const output = await Deno.readTextFile(

--- a/core/src/plugins/render/directives/classList/classList.test.ts
+++ b/core/src/plugins/render/directives/classList/classList.test.ts
@@ -22,7 +22,7 @@ globals();
 
 describe("classList directive", () => {
   test("renders", async () => {
-    using _ = new HandlerScope([
+    using _ = new HandlerScope(
       handleTransformFile,
       handlerFor(io.transformFile, id),
       handleComponents,
@@ -54,7 +54,7 @@ describe("classList directive", () => {
           },
         };
       }),
-    ]);
+    );
 
     const content = await Deno.readTextFile(join(testDataDir, "input.html"));
     const output = await Deno.readTextFile(

--- a/core/src/plugins/render/directives/html/html.test.ts
+++ b/core/src/plugins/render/directives/html/html.test.ts
@@ -22,7 +22,7 @@ globals();
 
 describe("html directive", () => {
   test("renders", async () => {
-    using _ = new HandlerScope([
+    using _ = new HandlerScope(
       handleTransformFile,
       handlerFor(io.transformFile, id),
       handleComponents,
@@ -54,7 +54,7 @@ describe("html directive", () => {
           },
         };
       }),
-    ]);
+    );
 
     const content = await Deno.readTextFile(join(testDataDir, "input.html"));
     const output = await Deno.readTextFile(

--- a/core/src/plugins/render/directives/text/text.test.ts
+++ b/core/src/plugins/render/directives/text/text.test.ts
@@ -22,7 +22,7 @@ globals();
 
 describe("text directive", () => {
   test("renders", async () => {
-    using _ = new HandlerScope([
+    using _ = new HandlerScope(
       handleTransformFile,
       handlerFor(io.transformFile, id),
       handleComponents,
@@ -54,7 +54,7 @@ describe("text directive", () => {
           },
         };
       }),
-    ]);
+    );
 
     const content = await Deno.readTextFile(join(testDataDir, "input.html"));
     const output = await Deno.readTextFile(

--- a/core/src/start.ts
+++ b/core/src/start.ts
@@ -38,8 +38,8 @@ export async function startApp(
   config: Config,
   getManifest: () => Promise<any>,
 ) {
-  const handlers = config.plugins?.flatMap((plugin) => plugin.handlers);
-  using _ = new effects.HandlerScope(handlers);
+  const handlers = config.plugins?.flatMap((plugin) => plugin.handlers) ?? [];
+  using _ = new effects.HandlerScope(...handlers);
 
   config = await configEffect.transform(config);
 

--- a/effect-system/deno.json
+++ b/effect-system/deno.json
@@ -9,5 +9,8 @@
     "exclude": [
       "**/*.md"
     ]
+  },
+  "publish": {
+    "exclude": ["**/*.test.ts"]
   }
 }

--- a/effect-system/effects.test.ts
+++ b/effect-system/effects.test.ts
@@ -128,7 +128,7 @@ describe("effect system", () => {
   });
 
   test("simple handling", async () => {
-    using _ = new HandlerScope([handleRandom]);
+    using _ = new HandlerScope(handleRandom);
 
     const number = await random();
 
@@ -138,7 +138,7 @@ describe("effect system", () => {
   });
 
   test("delegation", async () => {
-    using _ = new HandlerScope([handleIoReadTXT, handleIOReadBase]);
+    using _ = new HandlerScope(handleIoReadTXT, handleIOReadBase);
 
     const txt = await io.readFile("note.txt");
     const css = await io.readFile("style.css");
@@ -148,7 +148,7 @@ describe("effect system", () => {
   });
 
   test("missing terminal handler", async () => {
-    using _ = new HandlerScope([handleIoReadTXT]);
+    using _ = new HandlerScope(handleIoReadTXT);
 
     try {
       await io.readFile("style.css");
@@ -163,7 +163,7 @@ describe("effect system", () => {
   });
 
   test("dynamic handling", async () => {
-    using _ = new HandlerScope([]);
+    using _ = new HandlerScope();
     addHandlers([handleIoReadTXT]);
 
     const txt = await io.readFile("note.txt");
@@ -171,7 +171,7 @@ describe("effect system", () => {
   });
 
   test("dynamic delegation", async () => {
-    using _ = new HandlerScope([handleIOReadBase]);
+    using _ = new HandlerScope(handleIOReadBase);
     addHandlers([handleIoReadTXT]);
 
     const txt = await io.readFile("note.txt");
@@ -196,7 +196,7 @@ describe("effect system", () => {
 
   test("simple scoping", async () => {
     {
-      using _ = new HandlerScope([handleIOReadBase]);
+      using _ = new HandlerScope(handleIOReadBase);
 
       const txt = await io.readFile("note.txt");
       assertEquals(txt, "file content");
@@ -215,10 +215,10 @@ describe("effect system", () => {
   });
 
   test("handlers can be in a parent scope", async () => {
-    using _ = new HandlerScope([handleIOReadBase]);
+    using _ = new HandlerScope(handleIOReadBase);
 
     {
-      using __ = new HandlerScope([handleRandom]);
+      using __ = new HandlerScope(handleRandom);
 
       const content = await io.readFile("file");
       assertEquals(content, "file content");
@@ -226,8 +226,8 @@ describe("effect system", () => {
   });
 
   test("handlers can delegate to a parent scope handler", async () => {
-    using _ = new HandlerScope([handleIOReadBase]);
-    using __ = new HandlerScope([handleIoReadTXT]);
+    using _ = new HandlerScope(handleIOReadBase);
+    using __ = new HandlerScope(handleIoReadTXT);
 
     const content = await io.readFile("file.ts");
     assertEquals(content, "file content");
@@ -239,7 +239,7 @@ describe("effect system", () => {
       return `content of ${path}`;
     });
 
-    using _ = new HandlerScope([readAndLog, handleConsole]);
+    using _ = new HandlerScope(readAndLog, handleConsole);
 
     const res = await io.readFile("/path/to/file");
     assertEquals(logs, ["reading /path/to/file..."]);
@@ -256,7 +256,7 @@ describe("effect system", () => {
       return Handler.continue({ path, data });
     });
 
-    using _ = new HandlerScope([transformTXT.flatMap(id)]);
+    using _ = new HandlerScope(transformTXT.flatMap(id));
 
     const { data } = await io.transformFile({
       path: "note.txt",
@@ -277,12 +277,12 @@ describe("effect system", () => {
       await Console.log(`writing to "${path}": "${data}"`);
     });
 
-    using _ = new HandlerScope([
+    using _ = new HandlerScope(
       countWrites,
       handleWrite,
       ...state.handlers,
       handleConsole,
-    ]);
+    );
 
     await io.writeFile("todo.txt", "garden");
     await io.writeFile("styles.css", "some styles");

--- a/effect-system/effects.ts
+++ b/effect-system/effects.ts
@@ -105,7 +105,7 @@ export function createEffect<Op extends (...payload: any[]) => any>(
  *
  * Handlers for the same effect can be:
  * - **Synchronous** or **asynchronous**
- * - **Total** (handle all inputs) or **partial** (handle selectively)
+ * - **Total** (handles all inputs) or **partial** (handles selectively)
  *
  * and they can be freely mixed and composed as needed.
  *
@@ -131,7 +131,7 @@ export function createEffect<Op extends (...payload: any[]) => any>(
  *
  * Different handlers for the same effect can be synchronous or asynchronous.
  *
- * The operation signature (*e.g.* `A -> B`) is the minimal, effect-free contract. Handlers are free to perform their own effects, and asynchrony being an effect, async handlers (*e.g.* `A -> Promise<B>`) are allowed.
+ * The operation signature passed as the {@linkcode createEffect} type parameter (*e.g.* `A -> B`) is the minimal, effect-free contract. Handlers are free to perform their own effects, and asynchrony is an effect, so in particular async handlers (*e.g.* `A -> Promise<B>`) are allowed.
  *
  * ```ts
  * import { handlerFor } from "@radish/effect-system";
@@ -160,7 +160,7 @@ export function createEffect<Op extends (...payload: any[]) => any>(
  *
  * Handlers don't have to be total functions. They can be **partial**, handling only specific cases, and delegating the rest to other handlers.
  *
- * To delegate the handling we use {@linkcode Handler.continue Handler.continue(...)}  as shown below. You can modify arguments before forwarding them.
+ * Use {@linkcode Handler.continue Handler.continue(...args)} to delegate handling. You can modify arguments before forwarding them.
  *
  * This forwarding mechanism enables several powerful patterns:
  *
@@ -202,6 +202,8 @@ export function createEffect<Op extends (...payload: any[]) => any>(
  *
  * @param effect The effect we're implementing a handler for
  * @param handler The handler implementation
+ *
+ * @see {@linkcode Handler.continue}
  */
 export const handlerFor = <P extends any[], R>(
   effect: EffectWithId<P, R>,

--- a/effect-system/effects.ts
+++ b/effect-system/effects.ts
@@ -165,7 +165,7 @@ export function createEffect<Op extends (...payload: any[]) => any>(
  * This forwarding mechanism enables several powerful patterns:
  *
  * - **Delegation**: Focus on handling a specific case
- * - **Decoration**: Wrap or augment another handler
+ * - **Decoration**: Wrap or augment others handlers dynamically
  * - **Observation**: React to effects and do something orthogonal
  *
  * Handlers can also perform other effects while handling their own operation

--- a/effect-system/errors.ts
+++ b/effect-system/errors.ts
@@ -1,0 +1,42 @@
+class BaseError extends Error {
+  constructor(...params: ConstructorParameters<typeof Error>) {
+    super(...params);
+    this.name = this.constructor.name;
+    Error.captureStackTrace(this, UnhandledEffectError);
+  }
+}
+
+/**
+ * Error thrown when an effect has no handlers.
+ *
+ * @internal
+ */
+export class UnhandledEffectError extends BaseError {
+  constructor(id: string) {
+    super();
+    this.message = `Unhandled effect "${id}". Add handlers to the HandlerScope`;
+  }
+}
+
+/**
+ * Error thrown when there is no terminal handler for a given effect
+ *
+ * @internal
+ */
+export class MissingTerminalHandlerError extends BaseError {
+  constructor(id: string) {
+    super();
+    this.message =
+      `All handlers for "${id}" returned Handler.continue. Make sure the handlers sequence contains a terminal handler`;
+  }
+}
+
+/**
+ * Error thrown when there is no HandlerScope to dynamically add handlers to or to perform effects in.
+ *
+ * @internal
+ */
+export class MissingHandlerScopeError extends Error {
+  override message =
+    "No HandlerScope. Make sure to perform effects in the context of a HandlerScope";
+}

--- a/effect-system/handlers.ts
+++ b/effect-system/handlers.ts
@@ -3,7 +3,7 @@ import {
   MissingHandlerScopeError,
   MissingTerminalHandlerError,
   UnhandledEffectError,
-} from "./errors.Ts";
+} from "./errors.ts";
 
 /**
  * @internal
@@ -179,7 +179,7 @@ export class HandlerScope {
   #disposed = false;
 
   handlers = new Map<string, Handler<any, any>>();
-  store = new Map();
+  store = new Map<string, any>();
 
   /**
    * Creates a new {@linkcode HandlerScope}
@@ -286,7 +286,7 @@ export const Snapshot = () => {
   const handlersMap = handlerScopes.map((
     scope,
   ) => [...scope.handlers.values()]);
-  const stores = handlerScopes.map((scope) => scope.store);
+  const stores = handlerScopes.map((scope) => new Map(scope.store));
 
   assertEquals(handlersMap.length, stores.length);
 

--- a/effect-system/handlers.ts
+++ b/effect-system/handlers.ts
@@ -183,7 +183,10 @@ export class HandlerScope {
    *
    * @internal
    */
-  handlers = new Map<string, Handler<any, any>>();
+  handlers: Map<string, Handler<any, any>> = new Map<
+    string,
+    Handler<any, any>
+  >();
   /**
    * The internal store where {@linkcode HandlerScope HandlerScopes} keep track of AsyncState created with {@linkcode createState}
    *
@@ -191,7 +194,7 @@ export class HandlerScope {
    *
    * @internal
    */
-  store = new Map<string, any>();
+  store: Map<string, any> = new Map<string, any>();
 
   /**
    * Creates a new {@linkcode HandlerScope}
@@ -338,7 +341,7 @@ export class HandlerScope {
  *
  * @see {@linkcode createState}
  */
-export const Snapshot = () => {
+export const Snapshot = (): () => HandlerScope => {
   const handlersMap = handlerScopes.map((
     scope,
   ) => [...scope.handlers.values()]);

--- a/effect-system/handlers.ts
+++ b/effect-system/handlers.ts
@@ -114,7 +114,7 @@ export class Handler<P extends any[], R> {
    *
    * In a handlers sequence there must always be a terminal handler, that is, a handler that is a total function and does not delegate.
    *
-   * @throws If there is no terminal handler in the sequence
+   * @throws {MissingTerminalHandlerError} If there is no terminal handler in the sequence
    */
   static continue<P extends any[]>(...payload: P): Continue<P> {
     return new Continue(...payload);
@@ -159,7 +159,7 @@ export class Continue<P extends any[]> {
  * }
  *
  * // not in scope
- * await io.read("other/path"); // throws
+ * await io.read("other/path"); // throws UnhandledEffectError
  * ```
  *
  * @example Order handlers

--- a/effect-system/handlers.ts
+++ b/effect-system/handlers.ts
@@ -150,7 +150,7 @@ export class Continue<P extends any[]> {
  *
  * {@linkcode HandlerScope}s  have a parent-child relation and a handler is _in scope_ if it is in the current scope or any of its parents.
  *
- * @example Creating a new {@linkcode HandlerScope}
+ * @example Create a new {@linkcode HandlerScope}
  *
  * ```ts
  * {
@@ -162,9 +162,9 @@ export class Continue<P extends any[]> {
  * await io.read("other/path"); // throws
  * ```
  *
- * @example Ordering handlers
+ * @example Order handlers
  *
- * The order of the handlers matters when they rely on delegation via {@linkcode Handler.continue}
+ * The order of the handlers passed to the {@linkcode HandlerScope} constructor matters when they rely on delegation via {@linkcode Handler.continue}
  *
  * ```ts
  * using _ = new HandlerScope(handleTXTOnly, handleReadOp);
@@ -172,8 +172,6 @@ export class Continue<P extends any[]> {
  * const txtFile = await io.read("hello.txt"); // "I can only handle .txt files"
  * const jsonFile = await io.read("hello.json"); // ...
  * ```
- *
- * @throws If no handlers are in scope when trying to {@linkcode handle} an effect
  */
 export class HandlerScope {
   #parent: HandlerScope | undefined;
@@ -199,8 +197,6 @@ export class HandlerScope {
    * Creates a new {@linkcode HandlerScope}
    *
    * @param handlers A list of handlers
-   *
-   * @throws Throws "Unhandled effect" when an effect is performed with no handler in scope
    *
    * @see {@linkcode addHandlers}
    */

--- a/effect-system/handlers.ts
+++ b/effect-system/handlers.ts
@@ -142,7 +142,9 @@ export class Continue<P extends any[]> {
 }
 
 /**
- * A {@linkcode HandlerScope} creates a new scope where effects are handled
+ * A {@linkcode HandlerScope} creates a new scope where effects are handled and AsyncState is stored.
+ *
+ * Use `using` when creating a `HandlerScope` to have proper cleanup when leaving the scope
  *
  * The {@linkcode handle} method is responsible for finding handlers in scope for a given effect.
  *

--- a/effect-system/mod.ts
+++ b/effect-system/mod.ts
@@ -71,6 +71,7 @@ export {
   Handler,
   type Handlers,
   HandlerScope,
+  Snapshot,
 } from "./handlers.ts";
 
 /**
@@ -81,8 +82,6 @@ export {
  * @example
  *
  * ```ts
- * import { handlerFor } from "@radish/effect-system";
- *
  * const trivialHandler = handlerFor(io.transformFile, id);
  * ```
  */

--- a/effect-system/mod.ts
+++ b/effect-system/mod.ts
@@ -1,63 +1,90 @@
 /**
- * Structuring code with the Radish effect system unlocks testability, simplicity, modularity, extendability, customizability.
+ * Structuring code with an effect system unlocks **testability**, **simplicity**, **modularity**, **customizability**.
  *
- * - **Testability**: Swap handlers in a testing environment to easily mock a deep side-effect
- * - **Simplicity**: Avoid passing context or callbacks just for testability makes code simpler and more focused (single responsibility) with a thinner API.
- * - **Modularity**: Thinner APIs implies more reuseable and composable code
- * - **Extendability**: Define your own effects and handlers.
- * - **Customizability**: Consumers of your library/framework can extend & override your effects, giving a high level of control and customizability with a plugin API.
+ * - **Testability**: Swap handlers in a test environment to easily mock deep side-effects without modifying your API for testing purposes
+ * - **Simplicity**: Avoiding the need to pass context objects or callbacks solely for testing makes code simpler and more focused, with thinner, single responsibility APIs
+ * - **Modularity**: Thinner APIs with focused responsibilities make code more reuseable and composable
+ * - **Customizability**: Consumers of your library or framework can override effect handlers to suit their needs
  *
- * Use {@linkcode createEffect} to define an effect, and {@linkcode handlerFor} to implement a handler.
+ * ## Powerful Handler Patterns
  *
- * To create a new scope with handlers to run effects in {@linkcode HandlerScope}.
+ * Handlers can be:
+ * - synchronous or asynchronous
+ * - partial or total
  *
- * Handlers can also be added dynamically to a running programming with {@linkcode addHandlers}
+ * This flexibility enables powerful patterns like handler delegation, dynamic decoration and effect observation.
  *
- * @example Defining effects
+ * See {@linkcode handlerFor}
+ *
+ * ## AsyncState
+ *
+ * In stateful async workflows, you can create AsyncState and take snapshots of {@linkcode HandlerScope HandlerScopes}, including their handlers and store, and later restore these scopes, states and handlers across async boundaries, without race conditions or context loss.
+ *
+ * See {@linkcode Snapshot} and {@linkcode createState}
+ *
+ * ## Zero-effort Plugin API
+ *
+ * As a bonus, you get a plugin API out of the box: define your own effects and handlers, and allow consumers to extend and override them with their own handlers to suit their needs. This provides flexibility and a high level of control to your users
+ *
+ * @example Create a new effect
+ *
+ * Use {@linkcode createEffect} to create a new effect
  *
  * ```ts
  * import { createEffect } from "@radish/effect-system";
  *
  * const io = {
+ *   read: createEffect<(path: string) => string>('io/read'),
  *   transform: createEffect<(content: string)=> string>('io/transform'),
+ *   write: createEffect<(path: string, data: string)=> void>('io/write'),
  * }
  * ```
  *
- * @example Using effects
+ * @example Perform an effect
  *
- * When an effect is defined, we can use it in code type-safely without providing an implementation yet. This cleanly separates definition from implementation.
+ * We can already use the above effect without providing an implementation yet. This separates definition from implementation.
  *
  * To perform an effect operation we _await_ it. This allows the sequencing of effects in direct style.
  *
- * At runtime, performing an effect with no handler in scope will throw an "Unhandled effect" error.
- *
  * ```ts
- * // await to perform an effect
- * const transformed: string = await io.transform("some content");
+ * // a sequence of effects
+ * const content = await io.read("/path/to/input");
+ * const transformed = await io.transform(content);
+ * await io.write("/path/to/output", transformed);
  * ```
  *
- * @example Handling effects
+ * @example Create an effect handler
  *
- * {@linkcode handlerFor} creates a new handler for an effect
+ * Use {@linkcode handlerFor} to create a handler for a given effect
  *
  * ```ts
  * import { handlerFor } from "@radish/effect-system";
  *
+ * const handleIORead = handlerFor(io.read, (path: string) => {
+ *   return "my content";
+ * });
+ *
  * const handleIOTransform = handlerFor(io.transform, (content: string) => {
- *   return content;
+ *   return content.toUpperCase();
+ * });
+ *
+ * const handleIOWrite = handlerFor(io.transform, (path: string, data: string) => {
+ *   console.log(`writing to ${path}: ${data}`);
  * });
  * ```
  *
- * @example Running code with effects and handlers
+ * @example Perform effects with handlers in scope
  *
- * {@linkcode HandlerScope} creates a new scope where handlers can handle effects
+ * Use {@linkcode HandlerScope} to create a new scope with handlers to run effects in.
  *
  * ```ts
  * {
- *  using _ = new HandlerScope(handleIOTransform);
+ *  using _ = new HandlerScope(handleIORead, handleIOTransform, handleIOWrite);
  *
- *  const transformed = await io.transform("some content");
- *  console.log(transformed);
+ *  const content = await io.read("/path/to/input");
+ *  const transformed = await io.transform(content);
+ *  await io.write("/path/to/output", transformed);
+ *  // logs "writing to /path/to/output: MY CONTENT"
  * }
  * ```
  *

--- a/effect-system/mod.ts
+++ b/effect-system/mod.ts
@@ -54,7 +54,7 @@
  *
  * ```ts
  * {
- *  using _ = new HandlerScope([handleIOTransform]);
+ *  using _ = new HandlerScope(handleIOTransform);
  *
  *  const transformed = await io.transform("some content");
  *  console.log(transformed);

--- a/effect-system/state.ts
+++ b/effect-system/state.ts
@@ -1,0 +1,45 @@
+import { createEffect, handlerFor } from "./effects.ts";
+import { MissingHandlerScopeError } from "./errors.ts";
+import { handlerScopes } from "./handlers.ts";
+
+interface StateOps<T> {
+  get: () => T | undefined;
+  set: (state: T) => void;
+  update: (updater: (old: T) => T) => void;
+}
+
+export const createState = <T>(key: string, initialValue: T) => {
+  const scope = handlerScopes.at(-1);
+  if (!scope) throw new MissingHandlerScopeError();
+
+  const id = `${key}:${Date.now()}:${Math.random()}`;
+  const store = scope.store;
+
+  const get = createEffect<StateOps<T>["get"]>(`state/get/${id}`);
+  const set = createEffect<StateOps<T>["set"]>(`state/set/${id}`);
+  const update = createEffect<StateOps<T>["update"]>(`state/update/${id}`);
+
+  store.set(id, initialValue);
+
+  const handlers = [
+    handlerFor(get, () => {
+      return store.get(id);
+    }),
+    handlerFor(set, (newState) => {
+      store.set(id, newState);
+    }),
+    handlerFor(update, (updater) => {
+      const oldState = store.get(id);
+      const newState = updater(oldState);
+      store.set(id, newState);
+    }),
+  ];
+
+  scope.addHandlers(handlers);
+
+  return {
+    get,
+    set,
+    update,
+  };
+};

--- a/effect-system/state.ts
+++ b/effect-system/state.ts
@@ -2,13 +2,85 @@ import { createEffect, handlerFor } from "./effects.ts";
 import { MissingHandlerScopeError } from "./errors.ts";
 import { handlerScopes } from "./handlers.ts";
 
-interface StateOps<T> {
+/**
+ * Async State Operations
+ */
+export interface StateOps<T> {
+  /**
+   * Retrieves data
+   */
   get: () => T | undefined;
+  /**
+   * Sets data
+   */
   set: (state: T) => void;
+  /**
+   * Updates data
+   */
   update: (updater: (old: T) => T) => void;
 }
 
-export const createState = <T>(key: string, initialValue: T) => {
+/**
+ * Creates a new AsyncState
+ *
+ * This state can be safely used without race conditions in all contexts typically subject to context loss:
+ *
+ * - `await`
+ * - `Promise.then`
+ * - `setTimeout`
+ * - `queueMicrotask`
+ *
+ * When the execution context happens in a different scope or macrotask (like with `setTimeout`) you can capture the whole effect {@linkcode HandlerScope HandlerScopes} stack with {@linkcode Snapshot} and restore it using the snapshot.
+ *
+ * @example Avoid race conditions in async flows
+ *
+ * ```ts
+ * using _ = new HandlerScope();
+ *
+ * const processRequest = async (x: id) => {
+ *   const state = createState("requestId", x);
+ *   await delay(1); // do some async work
+ *   await state.update((x) => x * 2); // update state for demo purposes
+ *   return await state.get(); // retrieve the state later on
+ * };
+ *
+ * await Promise.all([1, 2, 3].map(processRequest)); // [2, 4, 6] as expected
+ * ```
+ * @example Snapshot state and schedule async work
+ *
+ * ```ts
+ * using _ = new HandlerScope();
+ *
+ *    // typically abstracted in a function
+ *    {
+ *      const state = createState("user", { id: "A" });
+ *      const snapshot = Snapshot();
+ *
+ *      setTimeout(async () => {
+ *        using _ = snapshot();
+ *        const user = await state.get();
+ *        assertEquals(user, { id: "A" }); // as expected
+ *      }, 20);
+ *    }
+ *
+ *    {
+ *      const state = createState("user", { id: "B" });
+ *      const snapshot = Snapshot();
+ *
+ *      setTimeout(async () => {
+ *        using _ = snapshot();
+ *        const user = await state.get();
+ *        assertEquals(user, { id: "B" });
+ *      }, 10); // no collisions
+ *    }
+ * ```
+ *
+ * @param key A key to name the state, used to the internal storage and for debugging purposes
+ * @param initialValue The initial value of the state or `undefined` if none is provided
+ *
+ * @throws {MissingHandlerScopeError} If the state is created outside a {@linkcode HandlerScope}
+ */
+export const createState = <T>(key: string, initialValue?: T) => {
   const scope = handlerScopes.at(-1);
   if (!scope) throw new MissingHandlerScopeError();
 

--- a/effect-system/tests/effects.test.ts
+++ b/effect-system/tests/effects.test.ts
@@ -21,7 +21,7 @@ import {
   MissingHandlerScopeError,
   MissingTerminalHandlerError,
   UnhandledEffectError,
-} from "../errors.Ts";
+} from "../errors.ts";
 
 /**
  * Tests

--- a/effect-system/tests/setup.ts
+++ b/effect-system/tests/setup.ts
@@ -1,0 +1,93 @@
+import { createEffect, Handler, handlerFor } from "../mod.ts";
+
+/**
+ * Console
+ */
+
+interface ConsoleOps {
+  log: (message: string) => void;
+}
+
+export const Console = { log: createEffect<ConsoleOps["log"]>("console/log") };
+
+export const logs: string[] = [];
+
+export const handleConsole = handlerFor(Console.log, (message: string) => {
+  logs.push(message);
+});
+
+/**
+ * State
+ */
+
+interface StateOps<S> {
+  get: () => S;
+  set: (state: S) => void;
+  update: (updater: (old: S) => S) => void;
+}
+
+export const createState = <S>(initialState: S) => {
+  const get = createEffect<StateOps<S>["get"]>("state/get");
+  const set = createEffect<StateOps<S>["set"]>("state/set");
+  const update = createEffect<StateOps<S>["update"]>("state/update");
+
+  let state = initialState;
+
+  return {
+    get,
+    set,
+    update,
+    handlers: [
+      handlerFor(get, () => state),
+      handlerFor(set, (newState) => {
+        state = newState;
+      }),
+      handlerFor(update, (updater) => {
+        state = updater(state);
+      }),
+    ],
+  };
+};
+
+/**
+ * Random
+ */
+
+interface RandomOps {
+  random: () => number;
+}
+
+export const random = createEffect<RandomOps["random"]>("random");
+
+export const handleRandom = handlerFor(random, () => Math.random());
+
+/**
+ * IO
+ */
+
+interface IO {
+  readFile: (path: string) => string;
+  writeFile: (path: string, data: string) => void;
+  transformFile: (
+    options: { path: string; data: string },
+  ) => { path: string; data: string };
+}
+
+export const io = {
+  readFile: createEffect<IO["readFile"]>("io/read"),
+  writeFile: createEffect<IO["writeFile"]>("io/write"),
+  transformFile: createEffect<
+    (options: { path: string; data: string }) => { path: string; data: string }
+  >("io/transform"),
+};
+
+export const handleIoReadTXT = handlerFor(io.readFile, (path: string) => {
+  if (path.endsWith(".txt")) {
+    return "txt content";
+  }
+  return Handler.continue(path);
+});
+
+export const handleIOReadBase = handlerFor(io.readFile, () => {
+  return "file content";
+});

--- a/effect-system/tests/snapshot.test.ts
+++ b/effect-system/tests/snapshot.test.ts
@@ -1,0 +1,66 @@
+import { describe, test } from "@std/testing/bdd";
+import { delay } from "@std/async";
+import { HandlerScope } from "../mod.ts";
+import { handleRandom, random } from "./setup.ts";
+import {
+  assert,
+  assertEquals,
+  assertInstanceOf,
+  unreachable,
+} from "@std/assert";
+import { Snapshot } from "../handlers.ts";
+import { MissingHandlerScopeError } from "../errors.Ts";
+
+describe("effects async", () => {
+  test("setTimeout executes after HandlerScopes are disposed of", async () => {
+    {
+      using _ = new HandlerScope(handleRandom);
+
+      setTimeout(async () => {
+        try {
+          await random();
+          unreachable();
+        } catch (error) {
+          assertInstanceOf(error, MissingHandlerScopeError);
+        }
+      }, 10);
+    }
+
+    await delay(20);
+  });
+
+  test("snapshot restores the scope inside setTimeout", async () => {
+    {
+      using _ = new HandlerScope(handleRandom);
+      const snapshot = Snapshot();
+
+      setTimeout(async () => {
+        using _ = snapshot();
+
+        const num = await random();
+        assert(typeof num === "number");
+      }, 10);
+    }
+
+    await delay(20);
+  });
+
+  test.ignore("single thread trying to do async doesn't work", async () => {
+    {
+      using _ = new HandlerScope(handleRandom);
+
+      let curr;
+      const double = async (x: number) => {
+        curr = x;
+        await delay(0);
+        return curr * 2;
+      };
+
+      const res = await Promise.all([1, 2, 3].map(double));
+
+      assertEquals(res, [2, 4, 6]);
+    }
+
+    await delay(1000);
+  });
+});

--- a/effect-system/tests/snapshot.test.ts
+++ b/effect-system/tests/snapshot.test.ts
@@ -12,6 +12,7 @@ describe("effects snapshots", () => {
       using _ = new HandlerScope(handleRandom);
 
       setTimeout(async () => {
+        // handlers are lost
         try {
           await random();
           unreachable();

--- a/effect-system/tests/snapshot.test.ts
+++ b/effect-system/tests/snapshot.test.ts
@@ -1,18 +1,13 @@
-import { describe, test } from "@std/testing/bdd";
+import { assert, assertInstanceOf, unreachable } from "@std/assert";
 import { delay } from "@std/async";
+import { describe, test } from "@std/testing/bdd";
+import { MissingHandlerScopeError } from "../errors.ts";
+import { Snapshot } from "../handlers.ts";
 import { HandlerScope } from "../mod.ts";
 import { handleRandom, random } from "./setup.ts";
-import {
-  assert,
-  assertEquals,
-  assertInstanceOf,
-  unreachable,
-} from "@std/assert";
-import { Snapshot } from "../handlers.ts";
-import { MissingHandlerScopeError } from "../errors.Ts";
 
-describe("effects async", () => {
-  test("setTimeout executes after HandlerScopes are disposed of", async () => {
+describe("effects snapshots", () => {
+  test("setTimeout executes after HandlerScope is disposed of", async () => {
     {
       using _ = new HandlerScope(handleRandom);
 
@@ -29,7 +24,7 @@ describe("effects async", () => {
     await delay(20);
   });
 
-  test("snapshot restores the scope inside setTimeout", async () => {
+  test("Snapshot restores the HandlerScope in setTimeout", async () => {
     {
       using _ = new HandlerScope(handleRandom);
       const snapshot = Snapshot();
@@ -43,24 +38,5 @@ describe("effects async", () => {
     }
 
     await delay(20);
-  });
-
-  test.ignore("single thread trying to do async doesn't work", async () => {
-    {
-      using _ = new HandlerScope(handleRandom);
-
-      let curr;
-      const double = async (x: number) => {
-        curr = x;
-        await delay(0);
-        return curr * 2;
-      };
-
-      const res = await Promise.all([1, 2, 3].map(double));
-
-      assertEquals(res, [2, 4, 6]);
-    }
-
-    await delay(1000);
   });
 });

--- a/effect-system/tests/state.test.ts
+++ b/effect-system/tests/state.test.ts
@@ -1,0 +1,71 @@
+import { describe, test } from "@std/testing/bdd";
+import { HandlerScope } from "../mod.ts";
+import { createState } from "../state.ts";
+import {
+  assertEquals,
+  assertExists,
+  assertInstanceOf,
+  assertNotEquals,
+  unreachable,
+} from "@std/assert";
+import { MissingHandlerScopeError } from "../errors.ts";
+import { delay } from "@std/async";
+
+describe("effect asyncState", () => {
+  test("needs a HandlerScope", () => {
+    try {
+      createState("requestId", 0);
+      unreachable();
+    } catch (error) {
+      assertInstanceOf(error, MissingHandlerScopeError);
+    }
+  });
+
+  test("get, set, update", async () => {
+    using _ = new HandlerScope();
+    const state = createState("requestId", 0);
+
+    let value = await state.get();
+    assertEquals(value, 0);
+
+    await state.set(1);
+    value = await state.get();
+    assertEquals(value, 1);
+
+    await state.update((x) => x * 2);
+    value = await state.get();
+    assertEquals(value, 2);
+  });
+
+  test("map(double) suffers async context loss", async () => {
+    let curr;
+
+    const double = async (x: number) => {
+      curr = x;
+      await delay(1);
+      return curr * 2;
+    };
+
+    const res = await Promise.all([1, 2, 3].map(double));
+
+    assertNotEquals(res, [2, 4, 6]);
+    assertEquals(res, [6, 6, 6]);
+  });
+
+  test.only("map(double) works with createState", async () => {
+    using _ = new HandlerScope();
+
+    const double = async (x: number) => {
+      const state = createState("requestId", x);
+      await delay(1);
+
+      const curr = await state.get();
+      assertExists(curr);
+      return curr * 2;
+    };
+
+    const res = await Promise.all([1, 2, 3].map(double));
+
+    assertEquals(res, [2, 4, 6]);
+  });
+});

--- a/effect-system/tests/state.test.ts
+++ b/effect-system/tests/state.test.ts
@@ -1,16 +1,15 @@
-import { beforeEach, describe, test } from "@std/testing/bdd";
-import { HandlerScope } from "../mod.ts";
-import { createState } from "../state.ts";
 import {
   assertEquals,
-  assertExists,
   assertInstanceOf,
   assertNotEquals,
   unreachable,
 } from "@std/assert";
-import { MissingHandlerScopeError } from "../errors.ts";
 import { delay } from "@std/async";
+import { beforeEach, describe, test } from "@std/testing/bdd";
+import { MissingHandlerScopeError } from "../errors.ts";
 import { Snapshot } from "../handlers.ts";
+import { HandlerScope } from "../mod.ts";
+import { createState } from "../state.ts";
 
 let currentContext: Record<string, any> | null = null;
 
@@ -65,7 +64,6 @@ describe("effect async state", () => {
       setTimeout(async () => {
         using _ = snapshot();
         const user = await state.get();
-        assertExists(user);
 
         // the snapshot reflects the updated data
         assertEquals(user, { name: "bobby" });
@@ -100,7 +98,6 @@ describe("async context loss patterns", () => {
       await delay(1);
       await state.update((x) => x * 2);
       const curr = await state.get();
-      assertExists(curr);
       return curr;
     };
 
@@ -138,21 +135,19 @@ describe("async context loss patterns", () => {
       setTimeout(async () => {
         using _ = snapshot();
         const user = await state.get();
-        assertExists(user);
         assertEquals(user, { id: "A" }); // as expected
-      }, 10);
+      }, 20);
     }
 
     {
-      const state2 = createState("user", { id: "B" });
-      const snapshot2 = Snapshot();
+      const state = createState("user", { id: "B" });
+      const snapshot = Snapshot();
 
       setTimeout(async () => {
-        using _ = snapshot2();
-        const user = await state2.get();
-        assertExists(user);
+        using _ = snapshot();
+        const user = await state.get();
         assertEquals(user, { id: "B" });
-      }, 20);
+      }, 10);
     }
 
     await delay(40);
@@ -178,7 +173,6 @@ describe("async context loss patterns", () => {
     Promise.resolve().then(() => {
       using _ = snapshot();
       state.get().then((u) => {
-        assertExists(u);
         assertEquals(u, { id: 4 });
       });
     });
@@ -188,7 +182,6 @@ describe("async context loss patterns", () => {
     Promise.resolve().then(() => {
       using _ = snapshot2();
       state2.get().then((u) => {
-        assertExists(u);
         assertEquals(u, { id: 5 });
       });
     });

--- a/effect-system/tests/state.test.ts
+++ b/effect-system/tests/state.test.ts
@@ -86,41 +86,49 @@ describe("effect async state", () => {
 
   test("setTimeout context loss", async () => {
     // Can't reliably schedule contextual operations
+    {
+      setContext({ id: "A" });
+      setTimeout(() => {
+        assertEquals(getContext(), { id: "B" }); // expected: { id: 'A' }
+      }, 10);
+    }
 
-    setContext({ id: "A" });
-    setTimeout(() => {
-      assertEquals(getContext(), { id: "B" }); // expected: { id: 'A' }
-    }, 10);
-
-    setContext({ id: "B" });
-    setTimeout(() => {
-      assertEquals(getContext(), { id: "B" });
-    }, 20);
+    {
+      setContext({ id: "B" });
+      setTimeout(() => {
+        assertEquals(getContext(), { id: "B" });
+      }, 20);
+    }
 
     await delay(40);
   });
 
   test("snapshot states keep track of their context", async () => {
     using _ = new HandlerScope();
-    const state = createState("user", { id: "A" });
-    const snapshot = Snapshot();
 
-    setTimeout(async () => {
-      using _ = snapshot();
-      const user = await state.get();
-      assertExists(user);
-      assertEquals(user, { id: "A" }); // as expected
-    }, 10);
+    {
+      const state = createState("user", { id: "A" });
+      const snapshot = Snapshot();
 
-    const state2 = createState("user", { id: "B" });
-    const snapshot2 = Snapshot();
+      setTimeout(async () => {
+        using _ = snapshot();
+        const user = await state.get();
+        assertExists(user);
+        assertEquals(user, { id: "A" }); // as expected
+      }, 10);
+    }
 
-    setTimeout(async () => {
-      using _ = snapshot2();
-      const user = await state2.get();
-      assertExists(user);
-      assertEquals(user, { id: "B" });
-    }, 20);
+    {
+      const state2 = createState("user", { id: "B" });
+      const snapshot2 = Snapshot();
+
+      setTimeout(async () => {
+        using _ = snapshot2();
+        const user = await state2.get();
+        assertExists(user);
+        assertEquals(user, { id: "B" });
+      }, 20);
+    }
 
     await delay(40);
   });


### PR DESCRIPTION
This turns `HandlerScopes` in `Disposable` objects that we can use with `using` in direct style, with no callback and no nesting

Adds a snapshot mechanism with `Snapshot` as well as `createState` to create and manage state in async flows without race conditions or context loss.

```ts
using _ = new HandlerScope(handleIO);
await io.read(path);

const state = createState('user', {id: 1});
const snapshot = Snapshot();

setTimeout(async ()=>{
  using _ = snapshot();
  const user = await state.get();
  console.log(user) // {id: 1}
}, 1000)
```