### PR TITLE
feat(core): add `onDispose` cleanup hook

### DIFF
--- a/core/deno.json
+++ b/core/deno.json
@@ -3,7 +3,7 @@
   "version": "1.0.0-alpha.39",
   "license": "MIT",
   "exports": {
-    ".": "./exports/mod.ts",
+    ".": "./src/mod.ts",
     "./parser": "./exports/parser.ts",
     "./utils": "./exports/utils.ts",
     "./environment": "./src/environment.ts",

--- a/core/exports/mod.ts
+++ b/core/exports/mod.ts
@@ -1,4 +1,0 @@
-export { importmapPath } from "$effects/importmap.ts";
-export { manifestPath } from "$effects/manifest.ts";
-export { globals } from "../src/constants.ts";
-export { startApp } from "../src/start.ts";

--- a/core/src/cleanup.ts
+++ b/core/src/cleanup.ts
@@ -1,0 +1,26 @@
+const resources = new AsyncDisposableStack();
+
+/**
+ * Registers an app-level resource cleanup hook to be called when the app is shutdown
+ *
+ * @example Cleanup the db connection
+ *
+ * ```ts
+ * export const db = await connectDB();
+ *
+ * onDispose(async () => {
+ *   await db.close();
+ *   console.log("DB connection closed");
+ * })
+ * ```
+ */
+export const onDispose = (callback: () => PromiseLike<void> | void) => {
+  resources.defer(callback);
+};
+
+/**
+ * @internal
+ */
+export const dispose = async () => {
+  await resources.disposeAsync();
+};

--- a/core/src/cleanup.ts
+++ b/core/src/cleanup.ts
@@ -14,7 +14,7 @@ const resources = new AsyncDisposableStack();
  * })
  * ```
  */
-export const onDispose = (callback: () => PromiseLike<void> | void) => {
+export const onDispose = (callback: () => PromiseLike<void> | void): void => {
   resources.defer(callback);
 };
 

--- a/core/src/effects/hot-update.ts
+++ b/core/src/effects/hot-update.ts
@@ -12,6 +12,7 @@ import { TtlCache } from "../utils/cache.ts";
 import { ws } from "../server/ws.ts";
 import { generateImportmap } from "../plugins/importmap/importmap.ts";
 import { createEffect, type EffectWithId } from "@radish/effect-system";
+import { onDispose } from "../cleanup.ts";
 
 type HotUpdateParam = {
   event: HmrEvent;
@@ -45,6 +46,11 @@ export const startHMR = async (): Promise<void> => {
     libFolder,
     staticFolder,
   ], { recursive: true });
+
+  onDispose(() => {
+    watcher?.close();
+    console.log("HMR closed");
+  });
 
   console.log("HRM server watching...");
 

--- a/core/src/mod.ts
+++ b/core/src/mod.ts
@@ -1,0 +1,5 @@
+export { importmapPath } from "$effects/importmap.ts";
+export { manifestPath } from "$effects/manifest.ts";
+export { globals } from "./constants.ts";
+export { startApp } from "./start.ts";
+export { onDispose } from "./cleanup.ts";


### PR DESCRIPTION
add an app-level `onDispose` cleanup hook to modularise cleanup logic (server, ws, hmr etc)

```ts
 export const db = await connectDB();

 onDispose(async () => {
   await db.close();
   console.log("DB connection closed");
 })
 ```
 