### PR TITLE
chore(core): update build/transform signature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,12 +3,11 @@
 
 deno.lock
 notebook.ipynb
+
 node_modules/
 coverage/
 docs/
 
-
 _generated/
-build/
-!core/**/build
+app/build/
 runtime/client/

--- a/core/src/effects/build.ts
+++ b/core/src/effects/build.ts
@@ -2,13 +2,12 @@ import type { WalkEntry } from "@std/fs";
 import { createEffect, type EffectWithId } from "@radish/effect-system";
 
 type BuildOptions = { incremental?: boolean };
-type FileTransformParam = { path: string; content: string };
 
 interface Build {
   sort: (entries: WalkEntry[]) => WalkEntry[];
   file: (path: string) => void;
   start: (paths: string[], options?: BuildOptions) => void;
-  transform: (option: FileTransformParam) => FileTransformParam;
+  transform: (path: string, content: string) => string;
   dest: (path: string) => string;
 }
 
@@ -19,7 +18,7 @@ export const build: {
     [paths: string[], options?: BuildOptions | undefined],
     void
   >;
-  transform: EffectWithId<[option: FileTransformParam], FileTransformParam>;
+  transform: EffectWithId<[path: string, content: string], string>;
   dest: EffectWithId<[path: string], string>;
 } = {
   /**

--- a/core/src/plugins/build/build.ts
+++ b/core/src/plugins/build/build.ts
@@ -20,10 +20,7 @@ import { buildHMRHook } from "./hooks/hmr.update.ts";
  */
 const handleBuildFile = handlerFor(build.file, async (path: string) => {
   const content = await io.read(path);
-  const { content: transformed } = await build.transform({
-    path,
-    content,
-  });
+  const transformed = await build.transform(path, content);
   const dest = await build.dest(path);
   await io.write(dest, transformed);
 });
@@ -74,7 +71,10 @@ const handleBuildSort = handlerFor(build.sort, id);
 /**
  * Canonically handles {@linkcode build.transform} effects as identity transforms
  */
-export const handlerBuildTransform = handlerFor(build.transform, id);
+export const handleBuildTransformCanonical = handlerFor(
+  build.transform,
+  (_, content) => content,
+);
 
 /**
  * Handles {@linkcode build.dest} effects
@@ -100,7 +100,7 @@ export const pluginBuild: Plugin = {
     handleBuildFile,
     handleBuildStart,
     handleBuildSort,
-    handlerBuildTransform,
+    handleBuildTransformCanonical,
     handleBuildDest,
     buildHMRHook,
   ],

--- a/core/src/plugins/build/build.ts
+++ b/core/src/plugins/build/build.ts
@@ -69,7 +69,7 @@ const handleBuildStart = handlerFor(
 const handleBuildSort = handlerFor(build.sort, id);
 
 /**
- * Canonically handles {@linkcode build.transform} effects as identity transforms
+ * Canonically handles {@linkcode build.transform} as an identity transform
  */
 export const handleBuildTransformCanonical = handlerFor(
   build.transform,

--- a/core/src/plugins/importmap/importmap.test.ts
+++ b/core/src/plugins/importmap/importmap.test.ts
@@ -1,7 +1,6 @@
 import { importmapPath } from "$effects/importmap.ts";
 import { io } from "$effects/io.ts";
 import { build } from "$effects/mod.ts";
-import { id } from "$lib/utils/algebraic-structures.ts";
 import { handlerFor, HandlerScope } from "@radish/effect-system";
 import { assertEquals } from "@std/assert";
 import { dirname, fromFileUrl, join } from "@std/path";
@@ -109,7 +108,7 @@ describe("importmap generation", () => {
         }
         return "";
       }),
-      handlerFor(build.transform, id),
+      handlerFor(build.transform, (_, content) => content),
     );
 
     const input = await Deno.readTextFile(
@@ -120,10 +119,7 @@ describe("importmap generation", () => {
       join(moduleDir, "testdata", "output.nofmt.html"),
     );
 
-    const { content } = await build.transform({
-      path: "_app.html",
-      content: input,
-    });
+    const content = await build.transform("_app.html", input);
 
     assertEquals(content, output);
   });

--- a/core/src/plugins/importmap/importmap.ts
+++ b/core/src/plugins/importmap/importmap.ts
@@ -42,9 +42,7 @@ export const pluginImportmap: Plugin = {
     handlerFor(importmap.write, async () => {
       await io.write(importmapPath, JSON.stringify(importmapObject));
     }),
-    handlerFor(build.transform, async (data) => {
-      let { path, content } = data;
-
+    handlerFor(build.transform, async (path, content) => {
       if (basename(path) === "_app.html") {
         const pageHeadContent = dedent`
         <script type="importmap">
@@ -60,7 +58,7 @@ export const pluginImportmap: Plugin = {
         content = content.replace(target_head, "\n" + pageHeadContent);
       }
 
-      return Handler.continue({ path, content });
+      return Handler.continue(path, content);
     }),
   ],
 };

--- a/core/src/plugins/render/directives/attr/attr.test.ts
+++ b/core/src/plugins/render/directives/attr/attr.test.ts
@@ -1,7 +1,6 @@
 import { manifest } from "$effects/manifest.ts";
 import { build } from "$effects/mod.ts";
 import { globals } from "$lib/constants.ts";
-import { id } from "$lib/utils/algebraic-structures.ts";
 import { handlerFor, HandlerScope } from "@radish/effect-system";
 import { fragments } from "@radish/htmlcrunch";
 import { assertEquals } from "@std/assert";
@@ -24,7 +23,7 @@ describe("attr directive", () => {
   test("renders", async () => {
     using _ = new HandlerScope(
       handleTransformFile,
-      handlerFor(build.transform, id),
+      handlerFor(build.transform, (_, content) => content),
       handleComponents,
       handleApplyDirectivesTransform,
       handleTransformBase,
@@ -57,10 +56,10 @@ describe("attr directive", () => {
     const content = await Deno.readTextFile(join(testDataDir, "input.html"));
     const output = await Deno.readTextFile(join(testDataDir, "output.html"));
 
-    const { content: transformed } = await build.transform({
-      path: "elements/my-component.html",
+    const transformed = await build.transform(
+      "elements/my-component.html",
       content,
-    });
+    );
 
     assertEquals(transformed, output);
   });

--- a/core/src/plugins/render/directives/bind/bind.test.ts
+++ b/core/src/plugins/render/directives/bind/bind.test.ts
@@ -1,7 +1,7 @@
 import { manifest } from "$effects/manifest.ts";
 import { build } from "$effects/mod.ts";
 import { globals } from "$lib/constants.ts";
-import { id } from "$lib/utils/algebraic-structures.ts";
+import { handleBuildTransformCanonical } from "$lib/plugins/build/build.ts";
 import { handlerFor, HandlerScope } from "@radish/effect-system";
 import { fragments } from "@radish/htmlcrunch";
 import { assertEquals } from "@std/assert";
@@ -24,7 +24,7 @@ describe("bind directive", () => {
   test("renders", async () => {
     using _ = new HandlerScope(
       handleTransformFile,
-      handlerFor(build.transform, id),
+      handleBuildTransformCanonical,
       handleComponents,
       handleApplyDirectivesTransform,
       handleTransformBase,
@@ -59,10 +59,10 @@ describe("bind directive", () => {
       join(testDataDir, "output.html"),
     );
 
-    const { content: transformed } = await build.transform({
-      path: "elements/my-component.html",
+    const transformed = await build.transform(
+      "elements/my-component.html",
       content,
-    });
+    );
 
     assertEquals(transformed, output);
   });

--- a/core/src/plugins/render/directives/bool/bool.test.ts
+++ b/core/src/plugins/render/directives/bool/bool.test.ts
@@ -1,7 +1,7 @@
 import { manifest } from "$effects/manifest.ts";
 import { build } from "$effects/mod.ts";
 import { globals } from "$lib/constants.ts";
-import { id } from "$lib/utils/algebraic-structures.ts";
+import { handleBuildTransformCanonical } from "$lib/plugins/build/build.ts";
 import { handlerFor, HandlerScope } from "@radish/effect-system";
 import { fragments } from "@radish/htmlcrunch";
 import { assertEquals } from "@std/assert";
@@ -24,7 +24,7 @@ describe("bool directive", () => {
   test("renders", async () => {
     using _ = new HandlerScope(
       handleTransformFile,
-      handlerFor(build.transform, id),
+      handleBuildTransformCanonical,
       handleComponents,
       handleApplyDirectivesTransform,
       handleTransformBase,
@@ -59,10 +59,10 @@ describe("bool directive", () => {
       join(testDataDir, "output.nofmt.html"),
     );
 
-    const { content: transformed } = await build.transform({
-      path: "elements/my-component.html",
+    const transformed = await build.transform(
+      "elements/my-component.html",
       content,
-    });
+    );
 
     assertEquals(transformed, output);
   });

--- a/core/src/plugins/render/directives/classList/classList.test.ts
+++ b/core/src/plugins/render/directives/classList/classList.test.ts
@@ -1,7 +1,7 @@
 import { manifest } from "$effects/manifest.ts";
 import { build } from "$effects/mod.ts";
 import { globals } from "$lib/constants.ts";
-import { id } from "$lib/utils/algebraic-structures.ts";
+import { handleBuildTransformCanonical } from "$lib/plugins/build/build.ts";
 import { handlerFor, HandlerScope } from "@radish/effect-system";
 import { fragments } from "@radish/htmlcrunch";
 import { assertEquals } from "@std/assert";
@@ -24,7 +24,7 @@ describe("classList directive", () => {
   test("renders", async () => {
     using _ = new HandlerScope(
       handleTransformFile,
-      handlerFor(build.transform, id),
+      handleBuildTransformCanonical,
       handleComponents,
       handleApplyDirectivesTransform,
       handleTransformBase,
@@ -61,10 +61,10 @@ describe("classList directive", () => {
       join(testDataDir, "output.html"),
     );
 
-    const { content: transformed } = await build.transform({
-      path: "elements/my-component.html",
+    const transformed = await build.transform(
+      "elements/my-component.html",
       content,
-    });
+    );
 
     assertEquals(transformed, output);
   });

--- a/core/src/plugins/render/directives/html/html.test.ts
+++ b/core/src/plugins/render/directives/html/html.test.ts
@@ -1,7 +1,7 @@
 import { manifest } from "$effects/manifest.ts";
 import { build } from "$effects/mod.ts";
 import { globals } from "$lib/constants.ts";
-import { id } from "$lib/utils/algebraic-structures.ts";
+import { handleBuildTransformCanonical } from "$lib/plugins/build/build.ts";
 import { handlerFor, HandlerScope } from "@radish/effect-system";
 import { fragments } from "@radish/htmlcrunch";
 import { assertEquals } from "@std/assert";
@@ -24,7 +24,7 @@ describe("html directive", () => {
   test("renders", async () => {
     using _ = new HandlerScope(
       handleTransformFile,
-      handlerFor(build.transform, id),
+      handleBuildTransformCanonical,
       handleComponents,
       handleApplyDirectivesTransform,
       handleTransformBase,
@@ -61,10 +61,10 @@ describe("html directive", () => {
       join(testDataDir, "output.nofmt.html"),
     );
 
-    const { content: transformed } = await build.transform({
-      path: "elements/my-component.html",
+    const transformed = await build.transform(
+      "elements/my-component.html",
       content,
-    });
+    );
 
     assertEquals(transformed, output);
   });

--- a/core/src/plugins/render/directives/text/text.test.ts
+++ b/core/src/plugins/render/directives/text/text.test.ts
@@ -1,7 +1,7 @@
 import { manifest } from "$effects/manifest.ts";
 import { build } from "$effects/mod.ts";
 import { globals } from "$lib/constants.ts";
-import { id } from "$lib/utils/algebraic-structures.ts";
+import { handleBuildTransformCanonical } from "$lib/plugins/build/build.ts";
 import { handlerFor, HandlerScope } from "@radish/effect-system";
 import { fragments } from "@radish/htmlcrunch";
 import { assertEquals } from "@std/assert";
@@ -24,7 +24,7 @@ describe("text directive", () => {
   test("renders", async () => {
     using _ = new HandlerScope(
       handleTransformFile,
-      handlerFor(build.transform, id),
+      handleBuildTransformCanonical,
       handleComponents,
       handleApplyDirectivesTransform,
       handleTransformBase,
@@ -61,10 +61,10 @@ describe("text directive", () => {
       join(testDataDir, "output.html"),
     );
 
-    const { content: transformed } = await build.transform({
-      path: "elements/my-component.html",
+    const transformed = await build.transform(
+      "elements/my-component.html",
       content,
-    });
+    );
 
     assertEquals(transformed, output);
   });

--- a/core/src/plugins/render/hooks/build.transform.ts
+++ b/core/src/plugins/render/hooks/build.transform.ts
@@ -17,8 +17,8 @@ import { manifestShape } from "./manifest.ts";
  */
 export const handleTransformFile = handlerFor(
   build.transform,
-  async ({ path, content }) => {
-    if (extname(path) !== ".html") return Handler.continue({ path, content });
+  async (path, content) => {
+    if (extname(path) !== ".html") return Handler.continue(path, content);
 
     const manifestObject = await manifest.get() as Manifest;
     assertObjectMatch(manifestObject, manifestShape);
@@ -29,21 +29,21 @@ export const handleTransformFile = handlerFor(
       const tagName = filename(path);
       const element = manifestObject.elements[tagName];
 
-      if (!element?.templateLoader) return Handler.continue({ path, content });
+      if (!element?.templateLoader) return Handler.continue(path, content);
 
       const rendered = await render.component(element);
-      return Handler.continue({ path, content: rendered });
+      return Handler.continue(path, rendered);
     }
 
     if (isParent(routesFolder, path)) {
       const route = manifestObject.routes[path];
 
-      if (!route) return Handler.continue({ path, content });
+      if (!route) return Handler.continue(path, content);
 
       const rendered = await render.route(route, "", "");
-      return Handler.continue({ path, content: rendered });
+      return Handler.continue(path, rendered);
     }
 
-    return Handler.continue({ path, content });
+    return Handler.continue(path, content);
   },
 );

--- a/core/src/plugins/strip-types.ts
+++ b/core/src/plugins/strip-types.ts
@@ -23,17 +23,14 @@ export const pluginStripTypes: Plugin = {
       }
       return Handler.continue(path);
     }),
-    handlerFor(build.transform, ({ path, content }) => {
+    handlerFor(build.transform, (path, content) => {
       if (extname(path) === ".ts" && !path.endsWith(".d.ts")) {
-        return {
-          path,
-          content: strip(content, {
-            removeComments: true,
-            pathRewriting: true,
-          }),
-        };
+        return strip(content, {
+          removeComments: true,
+          pathRewriting: true,
+        });
       }
-      return Handler.continue({ path, content });
+      return Handler.continue(path, content);
     }),
   ],
 };

--- a/core/src/plugins/ws/ws.test.ts
+++ b/core/src/plugins/ws/ws.test.ts
@@ -3,6 +3,7 @@ import { manifest } from "$effects/manifest.ts";
 import { build, config } from "$effects/mod.ts";
 import { render } from "$effects/render.ts";
 import { fragments } from "$lib/parser.ts";
+import { handleBuildTransformCanonical } from "$lib/plugins/build/build.ts";
 import { handleTransformFile } from "$lib/plugins/render/hooks/build.transform.ts";
 import { manifestShape } from "$lib/plugins/render/hooks/manifest.ts";
 import { handleRouteBase } from "$lib/plugins/render/routes/base.ts";
@@ -27,7 +28,7 @@ describe("ws plugin", () => {
       handleRouteLayoutsAndHeadElements,
       handleRouteBase,
       handlerFor(render.transformNode, id),
-      handlerFor(build.transform, id),
+      handleBuildTransformCanonical,
       handlerFor(build.dest, (path) => {
         if (path === "routes/_app.html") return "build/routes/_app.html";
         unreachable();
@@ -59,11 +60,7 @@ describe("ws plugin", () => {
       }),
     );
 
-    const { content: transformed } = await build.transform({
-      path: "routes/index.html",
-      content: input,
-    });
-
+    const transformed = await build.transform("routes/index.html", input);
     assertEquals(transformed, output);
   });
 });

--- a/effect-system/mod.ts
+++ b/effect-system/mod.ts
@@ -110,7 +110,7 @@ export { createState, type StateOps } from "./state.ts";
  * @example
  *
  * ```ts
- * const trivialHandler = handlerFor(build.transform, id);
+ * const trivialHandler = handlerFor(some.transform, id);
  * ```
  */
 export const id = <T>(value: T): T => value;


### PR DESCRIPTION
Simplifies the signature to `transform: (path: string, content: string) => string`