### PR TITLE
BREAKING(effect-system): remove `EffectWithId` symbol

### DIFF
--- a/core/src/effects/build.ts
+++ b/core/src/effects/build.ts
@@ -1,5 +1,5 @@
 import type { WalkEntry } from "@std/fs";
-import { createEffect, type EffectWithId } from "@radish/effect-system";
+import { createEffect, type Effect } from "@radish/effect-system";
 
 type BuildOptions = { incremental?: boolean };
 
@@ -12,14 +12,11 @@ interface Build {
 }
 
 export const build: {
-  file: EffectWithId<[path: string], void>;
-  sort: EffectWithId<[entries: WalkEntry[]], WalkEntry[]>;
-  start: EffectWithId<
-    [paths: string[], options?: BuildOptions | undefined],
-    void
-  >;
-  transform: EffectWithId<[path: string, content: string], string>;
-  dest: EffectWithId<[path: string], string>;
+  file: (path: string) => Effect<void>;
+  sort: (entries: WalkEntry[]) => Effect<WalkEntry[]>;
+  start: (paths: string[], options?: BuildOptions | undefined) => Effect<void>;
+  transform: (path: string, content: string) => Effect<string>;
+  dest: (path: string) => Effect<string>;
 } = {
   /**
    * Builds a single file

--- a/core/src/effects/config.ts
+++ b/core/src/effects/config.ts
@@ -1,32 +1,35 @@
 import type { Config } from "../types.d.ts";
-import { createEffect, type EffectWithId } from "@radish/effect-system";
+import { createEffect, type Effect } from "@radish/effect-system";
 
-interface ConfigEffect {
+interface ConfigOps {
   read: () => Config;
   transform: (config: Config) => Config;
 }
 
+/**
+ * The config effect
+ */
 export const config: {
-  read: EffectWithId<[], Config>;
-  transform: EffectWithId<[config: Config], Config>;
-} = {
   /**
    * Returns the resolved config object
    */
-  read: createEffect<ConfigEffect["read"]>("config/read"),
+  read: () => Effect<Config>;
   /**
    * Transforms the config object before it's resolved.
    */
-  transform: createEffect<ConfigEffect["transform"]>(
+  transform: (config: Config) => Effect<Config>;
+} = {
+  read: createEffect<ConfigOps["read"]>("config/read"),
+  transform: createEffect<ConfigOps["transform"]>(
     "config/transform",
   ),
 };
 
 export const denoConfig: {
-  read: EffectWithId<[], Record<string, any>>;
-} = {
   /**
    * Returns the parsed deno config and throws if it can't find it
    */
+  read: () => Effect<Record<string, any>>;
+} = {
   read: createEffect<() => Record<string, any>>("deno.config/read"),
 };

--- a/core/src/effects/env.ts
+++ b/core/src/effects/env.ts
@@ -1,20 +1,20 @@
-import { createEffect, type EffectWithId } from "@radish/effect-system";
+import { createEffect, type Effect } from "@radish/effect-system";
 
-interface Env {
+interface EnvOps {
   load: () => void;
   get: (key: string) => unknown;
 }
 
 export const env: {
-  load: EffectWithId<[], void>;
-  get: EffectWithId<[key: string], unknown>;
-} = {
   /**
    * Makes the environment variables available
    */
-  load: createEffect<Env["load"]>("env/load"),
+  load: () => Effect<void>;
   /**
    * Returns the parsed value of an environment variable
    */
-  get: createEffect<Env["get"]>("env/get"),
+  get: (key: string) => Effect<unknown>;
+} = {
+  load: createEffect<EnvOps["load"]>("env/load"),
+  get: createEffect<EnvOps["get"]>("env/get"),
 };

--- a/core/src/effects/hmr.ts
+++ b/core/src/effects/hmr.ts
@@ -1,4 +1,4 @@
-import { createEffect, type EffectWithId } from "@radish/effect-system";
+import { createEffect, type Effect } from "@radish/effect-system";
 
 export type HmrEvent = {
   /**
@@ -39,22 +39,22 @@ interface Hmr {
 }
 
 export const hmr: {
-  start: EffectWithId<[], void>;
-  pipeline: EffectWithId<[HmrEvent], void>;
-  update: EffectWithId<[param: HotUpdateParam], HotUpdateParam>;
-} = {
   /**
    * Starts the hmr server
    */
-  start: createEffect<Hmr["start"]>("hmr/start"),
+  start: () => Effect<void>;
   /**
    * Runs the hmr pipeline: performs an hmr/update, then updates the manifest and importmap, rebuilds relevant files and send a ws message
    */
-  pipeline: createEffect<Hmr["pipeline"]>("hmr/pipeline"),
+  pipeline: (event: HmrEvent) => Effect<void>;
   /**
    * Lets other plugins hook into the hot update transform on an {@linkcode HmrEvent}
    *
    * This is part of the hmr/pipeline
    */
+  update: (param: HotUpdateParam) => Effect<HotUpdateParam>;
+} = {
+  start: createEffect<Hmr["start"]>("hmr/start"),
+  pipeline: createEffect<Hmr["pipeline"]>("hmr/pipeline"),
   update: createEffect<Hmr["update"]>("hmr/update"),
 };

--- a/core/src/effects/importmap.ts
+++ b/core/src/effects/importmap.ts
@@ -1,6 +1,6 @@
 import { join } from "@std/path";
 import { generatedFolder } from "../constants.ts";
-import { createEffect, type EffectWithId } from "@radish/effect-system";
+import { createEffect, type Effect } from "@radish/effect-system";
 
 export interface ImportMap {
   imports?: Record<string, string>;
@@ -12,17 +12,17 @@ export interface ImportMap {
   };
 }
 
-interface ImportmapOperations {
+interface ImportmapOps {
   get: () => ImportMap;
   write: () => void;
 }
 
 export const importmap: {
-  get: EffectWithId<[], ImportMap>;
-  write: EffectWithId<[], void>;
+  get: () => Effect<ImportMap>;
+  write: () => Effect<void>;
 } = {
-  get: createEffect<ImportmapOperations["get"]>("importmap/get"),
-  write: createEffect<ImportmapOperations["write"]>("importmap/write"),
+  get: createEffect<ImportmapOps["get"]>("importmap/get"),
+  write: createEffect<ImportmapOps["write"]>("importmap/write"),
 };
 
 export const importmapPath: string = join(generatedFolder, "importmap.json");

--- a/core/src/effects/io.ts
+++ b/core/src/effects/io.ts
@@ -1,4 +1,4 @@
-import { createEffect, type EffectWithId } from "@radish/effect-system";
+import { createEffect, type Effect } from "@radish/effect-system";
 
 interface IO {
   read: (path: string) => string;
@@ -6,8 +6,14 @@ interface IO {
 }
 
 export const io: {
-  read: EffectWithId<[path: string], string>;
-  write: EffectWithId<[path: string, content: string], void>;
+  /**
+   * Reads a file from a path
+   */
+  read: (path: string) => Effect<string>;
+  /**
+   * Writes content to a path
+   */
+  write: (path: string, content: string) => Effect<void>;
 } = {
   read: createEffect<IO["read"]>("io/read"),
   write: createEffect<IO["write"]>("io/write"),

--- a/core/src/effects/manifest.ts
+++ b/core/src/effects/manifest.ts
@@ -2,7 +2,7 @@ import type { WalkEntry } from "@std/fs";
 import { join } from "@std/path";
 import { generatedFolder } from "../constants.ts";
 import type { ManifestBase } from "../types.d.ts";
-import { createEffect, type EffectWithId } from "@radish/effect-system";
+import { createEffect, type Effect } from "@radish/effect-system";
 
 /**
  * The path to the manifest file
@@ -23,34 +23,34 @@ interface ManifestOperations {
  * The manifest effect
  */
 export const manifest: {
-  setLoader: EffectWithId<[loader: () => Promise<ManifestBase>], void>;
-  load: EffectWithId<[], void>;
-  get: EffectWithId<[], ManifestBase>;
-  update: EffectWithId<[param: UpdateManifestParam], UpdateManifestParam>;
-  write: EffectWithId<[], void>;
-} = {
   /**
    * Sets the loader function used by `manifest/load`
    */
-  setLoader: createEffect<ManifestOperations["setLoader"]>(
-    "manifest/setLoader",
-  ),
+  setLoader: (loader: () => Promise<ManifestBase>) => Effect<void>;
   /**
    * Reads the manifest.ts file and loads its content in memory
    */
-  load: createEffect<ManifestOperations["load"]>("manifest/load"),
+  load: () => Effect<void>;
   /**
    * Returns the manifest object
    */
-  get: createEffect<ManifestOperations["get"]>("manifest/get"),
+  get: () => Effect<ManifestBase>;
   /**
    * Updates the manifest object in memory
    */
-  update: createEffect<ManifestOperations["update"]>(
-    "manifest/update",
-  ),
+  update: (param: UpdateManifestParam) => Effect<UpdateManifestParam>;
   /**
    * Serializes the manifest object and saves it to disk
    */
+  write: () => Effect<void>;
+} = {
+  setLoader: createEffect<ManifestOperations["setLoader"]>(
+    "manifest/setLoader",
+  ),
+  load: createEffect<ManifestOperations["load"]>("manifest/load"),
+  get: createEffect<ManifestOperations["get"]>("manifest/get"),
+  update: createEffect<ManifestOperations["update"]>(
+    "manifest/update",
+  ),
   write: createEffect<ManifestOperations["write"]>("manifest/write"),
 };

--- a/core/src/effects/render.ts
+++ b/core/src/effects/render.ts
@@ -1,5 +1,5 @@
 import type { MFragment, MNode } from "@radish/htmlcrunch";
-import { createEffect, type EffectWithId } from "@radish/effect-system";
+import { createEffect, type Effect } from "@radish/effect-system";
 import type { ManifestBase } from "../types.d.ts";
 import type { AnyConstructor } from "@std/assert";
 
@@ -34,7 +34,7 @@ export type Manifest = ManifestBase & {
   layouts: Record<string, LayoutManifest>;
 };
 
-interface RenderOperations {
+interface RenderOps {
   transformNode: (node: MNode) => MNode;
   component: (element: ElementManifest) => string;
   route: (
@@ -46,24 +46,25 @@ interface RenderOperations {
 }
 
 export const render: {
-  transformNode: EffectWithId<[node: MNode], MNode>;
-  component: EffectWithId<[element: ElementManifest], string>;
-  route: EffectWithId<
-    [route: RouteManifest, insertHead: string, insertBody: string],
-    string
-  >;
-  directive: EffectWithId<[node: MNode, key: string, value: string], void>;
-} = {
   /**
    * Prepares a node to be serialized
    */
-  transformNode: createEffect<RenderOperations["transformNode"]>(
-    "render/transformNode",
-  ),
-  component: createEffect<RenderOperations["component"]>("render/component"),
-  route: createEffect<RenderOperations["route"]>("render/route"),
+  transformNode: (node: MNode) => Effect<MNode>;
+  component: (element: ElementManifest) => Effect<string>;
+  route: (
+    route: RouteManifest,
+    insertHead: string,
+    insertBody: string,
+  ) => Effect<string>;
   /**
    * Asks for the interpretation of element attribute directives
    */
-  directive: createEffect<RenderOperations["directive"]>("render/directive"),
+  directive: (node: MNode, key: string, value: string) => Effect<void>;
+} = {
+  transformNode: createEffect<RenderOps["transformNode"]>(
+    "render/transformNode",
+  ),
+  component: createEffect<RenderOps["component"]>("render/component"),
+  route: createEffect<RenderOps["route"]>("render/route"),
+  directive: createEffect<RenderOps["directive"]>("render/directive"),
 };

--- a/core/src/effects/router.ts
+++ b/core/src/effects/router.ts
@@ -1,5 +1,5 @@
 import type { MaybePromise } from "$lib/types.d.ts";
-import { createEffect, type EffectWithId } from "@radish/effect-system";
+import { createEffect, type Effect } from "@radish/effect-system";
 
 export type RouteContext = {
   request: Request;
@@ -14,21 +14,27 @@ export type Route = {
   handleRoute: (context: RouteContext) => MaybePromise<Response>;
 };
 
-interface Router {
+interface RouterOps {
   init: () => void;
   addRoute: (route: Route) => void;
   handleRoute: (context: RouteContext) => MaybePromise<Response>;
 }
 
 export const router: {
-  init: EffectWithId<[], void>;
-  addRoute: EffectWithId<[route: Route], void>;
-  handleRoute: EffectWithId<
-    [context: RouteContext],
-    MaybePromise<Response>
-  >;
+  /**
+   * Initializes the router
+   */
+  init: () => Effect<void>;
+  /**
+   * Adds a route
+   */
+  addRoute: (route: Route) => Effect<void>;
+  /**
+   * Handles a requested route
+   */
+  handleRoute: (context: RouteContext) => Effect<MaybePromise<Response>>;
 } = {
-  init: createEffect<Router["init"]>("router/init"),
-  addRoute: createEffect<Router["addRoute"]>("router/add-route"),
-  handleRoute: createEffect<Router["handleRoute"]>("router/handle-route"),
+  init: createEffect<RouterOps["init"]>("router/init"),
+  addRoute: createEffect<RouterOps["addRoute"]>("router/add-route"),
+  handleRoute: createEffect<RouterOps["handleRoute"]>("router/handle-route"),
 };

--- a/core/src/effects/server.ts
+++ b/core/src/effects/server.ts
@@ -1,4 +1,4 @@
-import { createEffect, type EffectWithId } from "@radish/effect-system";
+import { createEffect, type Effect } from "@radish/effect-system";
 
 interface Server {
   start: (
@@ -13,18 +13,15 @@ interface Server {
 }
 
 export const server: {
-  start: EffectWithId<
-    [
-      options:
-        | Deno.ServeTcpOptions
-        | (Deno.ServeTcpOptions & Deno.TlsCertifiedKeyPem),
-    ],
-    void
-  >;
-  handleRequest: EffectWithId<
-    [request: Request, info: Deno.ServeHandlerInfo],
-    Response
-  >;
+  start: (
+    options:
+      | Deno.ServeTcpOptions
+      | (Deno.ServeTcpOptions & Deno.TlsCertifiedKeyPem),
+  ) => Effect<void>;
+  handleRequest: (
+    request: Request,
+    info: Deno.ServeHandlerInfo,
+  ) => Effect<Response>;
 } = {
   start: createEffect<Server["start"]>("server/start"),
   handleRequest: createEffect<Server["handleRequest"]>("server/handle-request"),

--- a/core/src/effects/ws.ts
+++ b/core/src/effects/ws.ts
@@ -1,4 +1,4 @@
-import { createEffect, type EffectWithId } from "@radish/effect-system";
+import { createEffect, type Effect } from "@radish/effect-system";
 
 interface WS {
   handleSocket: (socket: WebSocket) => void;
@@ -6,15 +6,15 @@ interface WS {
 }
 
 export const ws: {
-  handleSocket: EffectWithId<[WebSocket], void>;
-  send: EffectWithId<[string], void>;
-} = {
   /**
    * Handles a WebSocket
    */
-  handleSocket: createEffect<WS["handleSocket"]>("ws/socket"),
+  handleSocket: (socket: WebSocket) => Effect<void>;
   /**
    * Sends a message
    */
+  send: (message: string) => Effect<void>;
+} = {
+  handleSocket: createEffect<WS["handleSocket"]>("ws/socket"),
   send: createEffect<WS["send"]>("ws/send"),
 };

--- a/effect-system/errors.ts
+++ b/effect-system/errors.ts
@@ -40,3 +40,13 @@ export class MissingHandlerScopeError extends Error {
   override message =
     "No HandlerScope. Make sure to perform effects in the context of a HandlerScope";
 }
+
+/**
+ * Error thrown when an effect runner was created with {@linkcode createEffect}
+ *
+ * @internal
+ */
+export class IllFormedEffectError extends Error {
+  override message =
+    `Effect id not found while creating an effect handler. Use "createEffect"`;
+}

--- a/effect-system/mod.ts
+++ b/effect-system/mod.ts
@@ -94,7 +94,6 @@
 export { createEffect, type Effect, handlerFor } from "./effects.ts";
 export {
   addHandlers,
-  type BaseHandler,
   Handler,
   type Handlers,
   HandlerScope,
@@ -110,7 +109,7 @@ export { createState, type StateOps } from "./state.ts";
  * @example
  *
  * ```ts
- * const trivialHandler = handlerFor(some.transform, id);
+ * const trivialHandler = handlerFor(transformEffect, id);
  * ```
  */
 export const id = <T>(value: T): T => value;

--- a/effect-system/mod.ts
+++ b/effect-system/mod.ts
@@ -91,7 +91,7 @@
  * @module
  */
 
-export { createEffect, type EffectWithId, handlerFor } from "./effects.ts";
+export { createEffect, type Effect, handlerFor } from "./effects.ts";
 export {
   addHandlers,
   type BaseHandler,

--- a/effect-system/state.ts
+++ b/effect-system/state.ts
@@ -1,4 +1,4 @@
-import { createEffect, type EffectWithId, handlerFor } from "./effects.ts";
+import { createEffect, type Effect, handlerFor } from "./effects.ts";
 import { MissingHandlerScopeError } from "./errors.ts";
 import { handlerScopes } from "./handlers.ts";
 
@@ -78,9 +78,9 @@ export interface StateOps<T> {
  * @throws {MissingHandlerScopeError} If the state is created outside a {@linkcode HandlerScope}
  */
 export const createState = <T>(key: string, initialValue?: T): {
-  get: EffectWithId<[], T | undefined>;
-  set: EffectWithId<[state: T], void>;
-  update: EffectWithId<[updater: (old: T) => T], void>;
+  get: () => Effect<T | undefined>;
+  set: (state: T) => Effect<void>;
+  update: (updater: (old: T) => T) => Effect<void>;
 } => {
   const scope = handlerScopes.at(-1);
   if (!scope) throw new MissingHandlerScopeError();

--- a/effect-system/tests/effects.test.ts
+++ b/effect-system/tests/effects.test.ts
@@ -25,7 +25,7 @@ import {
   io,
   logs,
   random,
-} from "./setup.ts";
+} from "./setup.test.ts";
 
 /**
  * Tests

--- a/effect-system/tests/effects.test.ts
+++ b/effect-system/tests/effects.test.ts
@@ -6,8 +6,9 @@ import {
   unreachable,
 } from "@std/assert";
 import { afterEach, beforeEach, describe, test } from "@std/testing/bdd";
-import { handlerFor } from "../effects.ts";
+import { Effect, handlerFor } from "../effects.ts";
 import {
+  IllFormedEffectError,
   MissingHandlerScopeError,
   MissingTerminalHandlerError,
   UnhandledEffectError,
@@ -49,6 +50,46 @@ describe("effect system", () => {
     } catch (error) {
       assertInstanceOf(error, UnhandledEffectError);
     }
+  });
+
+  test("ill-formed effect", () => {
+    try {
+      handlerFor(() => new Effect(() => Promise.resolve(1)), () => 1);
+      unreachable();
+    } catch (error) {
+      assertInstanceOf(error, IllFormedEffectError);
+    }
+  });
+
+  test("scope cleanup", () => {
+    const logs: string[] = [];
+
+    {
+      using scope = new HandlerScope(handleRandom);
+      scope.onDispose(() => {
+        logs.push("clean");
+      });
+    }
+
+    assertEquals(logs, ["clean"]);
+  });
+
+  test("scope cleanup is idempotent", () => {
+    const logs: string[] = [];
+
+    {
+      using scope = new HandlerScope(handleRandom);
+
+      scope.onDispose(() => {
+        logs.push("clean");
+      });
+
+      scope[Symbol.dispose]();
+      scope[Symbol.dispose]();
+      scope[Symbol.dispose]();
+    }
+
+    assertEquals(logs, ["clean"]);
   });
 
   test("simple handling", async () => {

--- a/effect-system/tests/setup.test.ts
+++ b/effect-system/tests/setup.test.ts
@@ -1,5 +1,3 @@
-// deno-coverage-ignore-file
-
 import { createEffect, Handler, handlerFor } from "../mod.ts";
 
 /**
@@ -10,10 +8,19 @@ interface ConsoleOps {
   log: (message: string) => void;
 }
 
+/**
+ * @internal
+ */
 export const Console = { log: createEffect<ConsoleOps["log"]>("console/log") };
 
+/**
+ * @internal
+ */
 export const logs: string[] = [];
 
+/**
+ * @internal
+ */
 export const handleConsole = handlerFor(Console.log, (message: string) => {
   logs.push(message);
 });
@@ -28,6 +35,9 @@ interface StateOps<S> {
   update: (updater: (old: S) => S) => void;
 }
 
+/**
+ * @internal
+ */
 export const createState = <S>(initialState: S) => {
   const get = createEffect<StateOps<S>["get"]>("state/get");
   const set = createEffect<StateOps<S>["set"]>("state/set");
@@ -59,8 +69,14 @@ interface RandomOps {
   random: () => number;
 }
 
+/**
+ * @internal
+ */
 export const random = createEffect<RandomOps["random"]>("random");
 
+/**
+ * @internal
+ */
 export const handleRandom = handlerFor(random, () => Math.random());
 
 /**
@@ -75,6 +91,9 @@ interface IO {
   ) => { path: string; data: string };
 }
 
+/**
+ * @internal
+ */
 export const io = {
   readFile: createEffect<IO["readFile"]>("io/read"),
   writeFile: createEffect<IO["writeFile"]>("io/write"),
@@ -83,6 +102,9 @@ export const io = {
   >("io/transform"),
 };
 
+/**
+ * @internal
+ */
 export const handleIoReadTXT = handlerFor(io.readFile, (path: string) => {
   if (path.endsWith(".txt")) {
     return "txt content";
@@ -90,6 +112,9 @@ export const handleIoReadTXT = handlerFor(io.readFile, (path: string) => {
   return Handler.continue(path);
 });
 
+/**
+ * @internal
+ */
 export const handleIOReadBase = handlerFor(io.readFile, () => {
   return "file content";
 });

--- a/effect-system/tests/setup.ts
+++ b/effect-system/tests/setup.ts
@@ -1,3 +1,5 @@
+// deno-coverage-ignore-file
+
 import { createEffect, Handler, handlerFor } from "../mod.ts";
 
 /**

--- a/effect-system/tests/snapshot.test.ts
+++ b/effect-system/tests/snapshot.test.ts
@@ -4,7 +4,7 @@ import { describe, test } from "@std/testing/bdd";
 import { MissingHandlerScopeError } from "../errors.ts";
 import { Snapshot } from "../handlers.ts";
 import { HandlerScope } from "../mod.ts";
-import { handleRandom, random } from "./setup.ts";
+import { handleRandom, random } from "./setup.test.ts";
 
 describe("effects snapshots", () => {
   test("setTimeout executes after HandlerScope is disposed of", async () => {


### PR DESCRIPTION
Cleans-up the types for when you need to exliplitly type exported effect objects to avoid slow types.

The effect-system only export 5 types now: `Effect`, `Handler`, `Handlers`, `HandlerScope` and `StateOps`

```ts
export const read: (path: string) => Effect<string>  = createEffect<(path: string)=>string>("io/read");
```