### PR TITLE
feat(core): the io/read handler can read local or remote files

### DIFF
--- a/core/plugins/ws/hooks/render.route.ts
+++ b/core/plugins/ws/hooks/render.route.ts
@@ -9,7 +9,7 @@ const moduleDir = dirname(import.meta.url);
  *
  * @performs
  * - `config/read`
- * - `io/read` Retrieve the ws script to insert
+ * - `io/read` Retrieves the ws script to insert
  */
 export const handleInsertWebSocketScript = handlerFor(
   render.route,

--- a/core/plugins/ws/hooks/render.route.ts
+++ b/core/plugins/ws/hooks/render.route.ts
@@ -1,9 +1,8 @@
-import { config, render } from "$effects/mod.ts";
+import { config, io, render } from "$effects/mod.ts";
 import { Handler, handlerFor } from "@radish/effect-system";
 import { dirname, join } from "@std/path";
 
-const moduleDir = dirname(new URL(import.meta.url).pathname);
-const rawScript = Deno.readTextFileSync(join(moduleDir, "./script.nofmt.ts"));
+const moduleDir = dirname(import.meta.url);
 
 /**
  * Inserts WebSocket script in the head of routes to initiate a WebSocket connection to enable HMR
@@ -15,6 +14,8 @@ export const handleInsertWebSocketScript = handlerFor(
   render.route,
   async (route, insertHead, insertBody) => {
     const { args } = await config.read();
+    // the script can be remote in preview contexts
+    const rawScript = await io.read(join(moduleDir, "./script.nofmt.ts"));
 
     if (args?.dev) {
       insertHead += `<script>\n${

--- a/core/plugins/ws/hooks/render.route.ts
+++ b/core/plugins/ws/hooks/render.route.ts
@@ -9,6 +9,7 @@ const moduleDir = dirname(import.meta.url);
  *
  * @performs
  * - `config/read`
+ * - `io/read` Retrieve the ws script to insert
  */
 export const handleInsertWebSocketScript = handlerFor(
   render.route,

--- a/core/plugins/ws/ws.test.ts
+++ b/core/plugins/ws/ws.test.ts
@@ -1,6 +1,5 @@
-import { io } from "$effects/io.ts";
 import { manifest } from "$effects/manifest.ts";
-import { build, config } from "$effects/mod.ts";
+import { build, config, io } from "$effects/mod.ts";
 import { render } from "$effects/render.ts";
 import { fragments } from "$lib/parser.ts";
 import { handleBuildTransformCanonical } from "$lib/plugins/build/build.ts";
@@ -9,10 +8,11 @@ import { manifestShape } from "$lib/plugins/render/hooks/manifest.ts";
 import { handleRouteBase } from "$lib/plugins/render/routes/base.ts";
 import { handleRouteLayoutsAndHeadElements } from "$lib/plugins/render/routes/layouts-and-head.ts";
 import { id } from "$lib/utils/algebraic-structures.ts";
-import { handlerFor, HandlerScope } from "@radish/effect-system";
+import { Handler, handlerFor, HandlerScope } from "@radish/effect-system";
 import { assertEquals, unreachable } from "@std/assert";
 import { join } from "@std/path";
 import { describe, test } from "@std/testing/bdd";
+import { handleIORead } from "../io.ts";
 import { handleInsertWebSocketScript } from "./hooks/render.route.ts";
 
 const testDataDir = join(import.meta.dirname!, "testdata");
@@ -35,8 +35,10 @@ describe("ws plugin", () => {
       }),
       handlerFor(io.read, (path) => {
         if (path === "build/routes/_app.html") return app;
-        unreachable();
+        return Handler.continue(path);
       }),
+      // Needs to retrieve the ws script to insert
+      handleIORead,
       // Runs in dev mode
       handlerFor(config.read, () => {
         return { args: { dev: true } };

--- a/core/utils/path.ts
+++ b/core/utils/path.ts
@@ -1,13 +1,5 @@
 import { assert } from "@std/assert";
-import {
-  basename,
-  common,
-  extname,
-  isAbsolute,
-  normalize,
-  relative,
-  resolve,
-} from "@std/path";
+import { basename, common, extname, relative, resolve } from "@std/path";
 
 /**
  * Returns the file name without the extension
@@ -22,11 +14,8 @@ export function filename(path: string): string {
  * Normalizes paths relative to the project workspace
  */
 export const workspaceRelative = (path: string) => {
-  const normalized = normalize(path);
-  if (isAbsolute(normalized)) {
-    return relative(Deno.cwd(), normalized);
-  }
-  return normalized;
+  const resolved = resolve(path);
+  return relative(Deno.cwd(), resolved);
 };
 
 /**


### PR DESCRIPTION
Now you can do 

```ts
await io.read("./mod.ts");
await io.read("/usr/bin/config.txt");
await io.read("file:///home/foo");
await io.read("http://site.com/bar.txt");
```

and the result is cached for subsequent reads