### PR TITLE
feat(effect-system): export Plugin API

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,6 @@
       "program": "${file}",
       "runtimeArgs": [
         "run",
-        "--unstable",
         "--inspect-wait",
         "--allow-all"
       ],
@@ -30,7 +29,6 @@
       "program": "${file}",
       "runtimeArgs": [
         "test",
-        "--unstable",
         "--inspect-wait",
         "--allow-all",
         "--no-check"
@@ -48,7 +46,6 @@
       "program": "${file}",
       "runtimeArgs": [
         "run",
-        "--unstable",
         "--inspect-wait",
         "--allow-all",
         "--config",

--- a/core/mod.ts
+++ b/core/mod.ts
@@ -3,4 +3,4 @@ export { manifestPath } from "$effects/manifest.ts";
 export { onDispose } from "./cleanup.ts";
 export { globals } from "./constants.ts";
 export { startApp } from "./start.ts";
-export type { Config, ManifestBase, Plugin } from "./types.d.ts";
+export type { Config, ManifestBase } from "./types.d.ts";

--- a/core/plugins/build/build.ts
+++ b/core/plugins/build/build.ts
@@ -1,11 +1,10 @@
 import { build } from "$effects/build.ts";
 import { io } from "$effects/io.ts";
 import { buildFolder } from "$lib/constants.ts";
-import type { Plugin } from "$lib/types.d.ts";
 import { id } from "$lib/utils/algebraic-structures.ts";
 import { expandGlobWorkspaceRelative } from "$lib/utils/fs.ts";
 import { workspaceRelative } from "$lib/utils/path.ts";
-import { handlerFor } from "@radish/effect-system";
+import { handlerFor, type Plugin } from "@radish/effect-system";
 import { distinctBy } from "@std/collections";
 import { emptyDirSync, ensureDirSync, type WalkEntry } from "@std/fs";
 import { join } from "@std/path";

--- a/core/plugins/config.ts
+++ b/core/plugins/config.ts
@@ -1,8 +1,7 @@
 import { assertExists } from "@std/assert";
 import { existsSync } from "@std/fs";
 import * as JSONC from "@std/jsonc";
-import { handlerFor } from "@radish/effect-system";
-import type { Plugin } from "../types.d.ts";
+import { handlerFor, type Plugin } from "@radish/effect-system";
 import { io } from "$effects/io.ts";
 import { config, denoConfig } from "$effects/config.ts";
 import { id } from "../utils/algebraic-structures.ts";

--- a/core/plugins/env/env.ts
+++ b/core/plugins/env/env.ts
@@ -1,8 +1,7 @@
 import { config, env, hmr, io } from "$effects/mod.ts";
 import { generatedFolder } from "$lib/constants.ts";
-import type { Plugin } from "$lib/types.d.ts";
 import { stringifyObject } from "$lib/utils/stringify.ts";
-import { Handler, handlerFor } from "@radish/effect-system";
+import { Handler, handlerFor, type Plugin } from "@radish/effect-system";
 import { parse } from "@std/dotenv";
 import { join } from "@std/path";
 

--- a/core/plugins/hmr/hmr.ts
+++ b/core/plugins/hmr/hmr.ts
@@ -33,45 +33,46 @@ const handleHMRPipeline = handlerFor(hmr.pipeline, async (event: HmrEvent) => {
   await ws.send("reload");
 });
 
+const handleHMRStart = handlerFor(hmr.start, async (): Promise<void> => {
+  watcher = Deno.watchFs([
+    elementsFolder,
+    routesFolder,
+    libFolder,
+    staticFolder,
+  ], { recursive: true });
+
+  console.log("HRM server watching...");
+
+  for await (const event of watcher) {
+    console.log(`FS Event`, event.kind, event.paths, Date.now());
+
+    for (const path of event.paths) {
+      const relativePath = relative(Deno.cwd(), path);
+      const key = `${event.kind}:${path}`;
+
+      if (!hmrEventsCache.has(key)) {
+        const hmrEvent: HmrEvent = {
+          isFile: !!extname(path),
+          path: relativePath,
+          kind: event.kind,
+          timestamp: Date.now(),
+        };
+        hmrEventsCache.set(key, hmrEvent);
+        await hmr.pipeline(hmrEvent);
+      }
+    }
+  }
+});
+handleHMRStart[Symbol.dispose] = () => {
+  hmrEventsCache.clear();
+  watcher?.close();
+  console.log("HMR closed");
+};
+
 export const pluginHMR: Plugin = {
   name: "plugin-hmr",
   handlers: [
     handleHMRPipeline,
     handlerFor(hmr.update, id),
-    handlerFor(hmr.start, async (): Promise<void> => {
-      watcher = Deno.watchFs([
-        elementsFolder,
-        routesFolder,
-        libFolder,
-        staticFolder,
-      ], { recursive: true });
-
-      console.log("HRM server watching...");
-
-      for await (const event of watcher) {
-        console.log(`FS Event`, event.kind, event.paths, Date.now());
-
-        for (const path of event.paths) {
-          const relativePath = relative(Deno.cwd(), path);
-          const key = `${event.kind}:${path}`;
-
-          if (!hmrEventsCache.has(key)) {
-            const hmrEvent: HmrEvent = {
-              isFile: !!extname(path),
-              path: relativePath,
-              kind: event.kind,
-              timestamp: Date.now(),
-            };
-            hmrEventsCache.set(key, hmrEvent);
-            await hmr.pipeline(hmrEvent);
-          }
-        }
-      }
-    }),
   ],
-  onDispose: (() => {
-    hmrEventsCache.clear();
-    watcher?.close();
-    console.log("HMR closed");
-  }),
 };

--- a/core/plugins/importmap/importmap.ts
+++ b/core/plugins/importmap/importmap.ts
@@ -6,9 +6,9 @@ import {
 import { build, config, denoConfig, io, manifest } from "$effects/mod.ts";
 import { target_head, ts_extension_regex } from "$lib/constants.ts";
 import { dev } from "$lib/environment.ts";
-import type { ManifestBase, Plugin } from "$lib/types.d.ts";
+import type { ManifestBase } from "$lib/types.d.ts";
 import { throwUnlessNotFound } from "$lib/utils/io.ts";
-import { Handler, handlerFor } from "@radish/effect-system";
+import { Handler, handlerFor, type Plugin } from "@radish/effect-system";
 import { assert, assertExists, assertMatch, unimplemented } from "@std/assert";
 import { basename, extname } from "@std/path";
 import { dedent } from "@std/text/unstable-dedent";
@@ -61,6 +61,9 @@ export const pluginImportmap: Plugin = {
       return Handler.continue(path, content);
     }),
   ],
+  onDispose: () => {
+    importmapObject = {};
+  },
 };
 
 /**

--- a/core/plugins/io.ts
+++ b/core/plugins/io.ts
@@ -1,8 +1,7 @@
 import { hmr } from "$effects/hmr.ts";
 import { io } from "$effects/io.ts";
-import type { Plugin } from "$lib/types.d.ts";
 import { workspaceRelative } from "$lib/utils/path.ts";
-import { Handler, handlerFor } from "@radish/effect-system";
+import { Handler, handlerFor, type Plugin } from "@radish/effect-system";
 import { unimplemented } from "@std/assert";
 import { ensureDir } from "@std/fs";
 import { dirname, fromFileUrl } from "@std/path";
@@ -116,4 +115,7 @@ export const pluginIO: Plugin = {
       return Handler.continue({ event, paths });
     }),
   ],
+  onDispose: () => {
+    fileCache.clear();
+  },
 };

--- a/core/plugins/io.ts
+++ b/core/plugins/io.ts
@@ -68,6 +68,9 @@ export const handleIORead = handlerFor(io.read, async (path) => {
     throw error;
   }
 });
+handleIORead[Symbol.dispose] = () => {
+  fileCache.clear();
+};
 
 /**
  * Handles {@linkcode io.write} effects
@@ -115,7 +118,4 @@ export const pluginIO: Plugin = {
       return Handler.continue({ event, paths });
     }),
   ],
-  onDispose: () => {
-    fileCache.clear();
-  },
 };

--- a/core/plugins/manifest/manifest.ts
+++ b/core/plugins/manifest/manifest.ts
@@ -1,18 +1,17 @@
 import { hmr } from "$effects/hmr.ts";
 import { io } from "$effects/io.ts";
 import { manifest, manifestPath } from "$effects/manifest.ts";
-import { Handler, handlerFor } from "@radish/effect-system";
+import { generatedFolder } from "$lib/constants.ts";
+import type { ManifestBase } from "$lib/types.d.ts";
+import { expandGlobWorkspaceRelative } from "$lib/utils/fs.ts";
+import { extractImports } from "$lib/utils/parse.ts";
+import { stringifyObject } from "$lib/utils/stringify.ts";
+import { Handler, handlerFor, type Plugin } from "@radish/effect-system";
 import { assertExists } from "@std/assert";
 import { ensureDirSync, type ExpandGlobOptions } from "@std/fs";
 import { extname } from "@std/path";
-import { generatedFolder } from "../../constants.ts";
-import type { ManifestBase, Plugin } from "../../types.d.ts";
-import { expandGlobWorkspaceRelative } from "../../utils/fs.ts";
-import { extractImports } from "../../utils/parse.ts";
-import { stringifyObject } from "../../utils/stringify.ts";
 
 let loader: (() => Promise<ManifestBase>) | undefined;
-
 let manifestObject: ManifestBase = { imports: {} };
 
 /**
@@ -66,6 +65,10 @@ export const pluginManifest: Plugin = {
       return Handler.continue({ event, paths });
     }),
   ],
+  onDispose: () => {
+    loader = undefined;
+    manifestObject = { imports: {} };
+  },
 };
 
 /**

--- a/core/plugins/render/mod.ts
+++ b/core/plugins/render/mod.ts
@@ -1,9 +1,9 @@
-import type { Plugin } from "$lib/types.d.ts";
+import type { Plugin } from "@radish/effect-system";
 import { handleRenderComponents } from "./components/component.ts";
 import { handleDirectives } from "./directives/mod.ts";
 import { handleSort } from "./hooks/build.sort.ts";
-import { handleHotUpdate } from "./hooks/hmr.update.ts";
 import { handleTransformFile } from "./hooks/build.transform.ts";
+import { handleHotUpdate } from "./hooks/hmr.update.ts";
 import { handleManifest } from "./hooks/manifest.ts";
 import { handleRoutes } from "./routes/mod.ts";
 import { handleTransformNode } from "./transforms/mod.ts";

--- a/core/plugins/resolve.ts
+++ b/core/plugins/resolve.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from "../types.d.ts";
+import type { Plugin } from "@radish/effect-system";
 
 export const pluginResolveModule: Plugin = {
   name: "plugin-resolve",

--- a/core/plugins/router/router.ts
+++ b/core/plugins/router/router.ts
@@ -4,11 +4,15 @@ import { build } from "$effects/mod.ts";
 import type { Manifest } from "$effects/render.ts";
 import { type Route, type RouteContext, router } from "$effects/router.ts";
 import { routesFolder } from "$lib/constants.ts";
-import type { Plugin } from "$lib/mod.ts";
 import { manifestShape } from "$lib/plugins/render/hooks/manifest.ts";
 import type { MaybePromise } from "$lib/types.d.ts";
 import { createStandardResponse } from "$lib/utils/http.ts";
-import { addHandlers, Handler, handlerFor } from "@radish/effect-system";
+import {
+  addHandlers,
+  Handler,
+  handlerFor,
+  type Plugin,
+} from "@radish/effect-system";
 import { assertExists, assertObjectMatch } from "@std/assert";
 import { serveFile, STATUS_CODE } from "@std/http";
 import { dirname } from "@std/path";

--- a/core/plugins/server/mod.ts
+++ b/core/plugins/server/mod.ts
@@ -64,6 +64,10 @@ export const handleServerStart = handlerFor(server.start, (options) => {
   Deno.addSignalListener("SIGINT", shutdown);
   Deno.addSignalListener("SIGTERM", shutdown);
 });
+handleServerStart[Symbol.asyncDispose] = async () => {
+  await httpServer?.shutdown();
+  console.log("Server closed");
+};
 
 const shutdown = async () => {
   console.log("\nShutting down gracefully...");
@@ -78,8 +82,4 @@ const shutdown = async () => {
 export const pluginServer: Plugin = {
   name: "plugin-server",
   handlers: [handleServerStart, handleServerRequest],
-  onDispose: async () => {
-    await httpServer?.shutdown();
-    console.log("Server closed");
-  },
 };

--- a/core/plugins/strip-types.ts
+++ b/core/plugins/strip-types.ts
@@ -1,9 +1,8 @@
 import { build } from "$effects/mod.ts";
 import strip from "@fcrozatier/type-strip";
-import { Handler, handlerFor } from "@radish/effect-system";
+import { Handler, handlerFor, type Plugin } from "@radish/effect-system";
 import { extname, join } from "@std/path";
 import { buildFolder, ts_extension_regex } from "../constants.ts";
-import type { Plugin } from "../types.d.ts";
 
 /**
  * The type-stripping plugin

--- a/core/plugins/ws/ws.ts
+++ b/core/plugins/ws/ws.ts
@@ -1,21 +1,10 @@
 import { ws } from "$effects/ws.ts";
-import { handlerFor } from "@radish/effect-system";
-import { onDispose } from "$lib/cleanup.ts";
-import type { Plugin } from "$lib/mod.ts";
+import { dev } from "$lib/environment.ts";
+import { handlerFor, type Plugin } from "@radish/effect-system";
 import { handleInsertWebSocketScript } from "./hooks/render.route.ts";
 import { handleWSServerRequest } from "./hooks/server.handle-request.ts";
-import { dev } from "$lib/environment.ts";
 
 const clients = new Set<WebSocket>();
-
-onDispose(() => {
-  if (clients) {
-    for (const client of clients) client.close();
-    clients.clear();
-
-    if (dev) console.log("WebSocket connection closed");
-  }
-});
 
 const handleWSSend = handlerFor(ws.send, (payload) => {
   console.log("Hot-Reloading...");
@@ -62,4 +51,12 @@ export const pluginWS: Plugin = {
     handleInsertWebSocketScript,
     handleWSServerRequest,
   ],
+  onDispose: (() => {
+    if (clients) {
+      for (const client of clients) client.close();
+      clients.clear();
+
+      if (dev) console.log("WebSocket connection closed");
+    }
+  }),
 };

--- a/core/plugins/ws/ws.ts
+++ b/core/plugins/ws/ws.ts
@@ -32,6 +32,14 @@ const handleWSHandleSocket = handlerFor(ws.handleSocket, (socket) => {
     console.log("WebSocket error", e);
   });
 });
+handleWSHandleSocket[Symbol.dispose] = () => {
+  if (clients) {
+    for (const client of clients) client.close();
+    clients.clear();
+
+    if (dev) console.log("WebSocket connection closed");
+  }
+};
 
 /**
  * The WebSocket plugin
@@ -51,12 +59,4 @@ export const pluginWS: Plugin = {
     handleInsertWebSocketScript,
     handleWSServerRequest,
   ],
-  onDispose: (() => {
-    if (clients) {
-      for (const client of clients) client.close();
-      clients.clear();
-
-      if (dev) console.log("WebSocket connection closed");
-    }
-  }),
 };

--- a/core/start.ts
+++ b/core/start.ts
@@ -37,7 +37,7 @@ export async function startApp(
 ) {
   const plugins = config.plugins ?? [];
   const scope = new effects.HandlerScope(...plugins);
-  onDispose(() => scope[Symbol.dispose]());
+  onDispose(scope[Symbol.asyncDispose]);
 
   config = await configEffect.transform({ ...config, args: cliArgs });
   const resolvedConfig: Config = Object.freeze(config);

--- a/core/start.ts
+++ b/core/start.ts
@@ -25,6 +25,7 @@ import { generateImportmap } from "./plugins/importmap/importmap.ts";
 import { updateManifest } from "./plugins/manifest/manifest.ts";
 import { SERVER_DEFAULTS } from "./plugins/server/mod.ts";
 import type { CLIArgs, Config } from "./types.d.ts";
+import { onDispose } from "./mod.ts";
 
 const cliArgs: CLIArgs = Object.freeze(parseArgs(Deno.args, {
   boolean: ["dev", "env", "importmap", "manifest", "build", "server"],
@@ -34,8 +35,9 @@ export async function startApp(
   config: Config,
   getManifest: () => Promise<any>,
 ) {
-  const handlers = config.plugins?.flatMap((plugin) => plugin.handlers) ?? [];
-  new effects.HandlerScope(...handlers);
+  const plugins = config.plugins ?? [];
+  const scope = new effects.HandlerScope(...plugins);
+  onDispose(() => scope[Symbol.dispose]());
 
   config = await configEffect.transform({ ...config, args: cliArgs });
   const resolvedConfig: Config = Object.freeze(config);

--- a/core/types.d.ts
+++ b/core/types.d.ts
@@ -1,4 +1,4 @@
-import type { Handlers } from "@radish/effect-system";
+import type { Plugin } from "@radish/effect-system";
 import type { SpeculationRules } from "./generate/speculationrules.ts";
 import type { ImportMapOptions } from "./plugins/importmap/importmap.ts";
 
@@ -9,17 +9,6 @@ export interface ManifestBase extends Record<string, any> {
    * Maps module paths to their import specifiers
    */
   imports: Record<string, string[]>;
-}
-
-export interface Plugin {
-  /**
-   * The name of the plugin
-   */
-  name: string;
-  /**
-   * The plugin handlers
-   */
-  handlers: Handlers;
 }
 
 export interface Config {

--- a/effect-system/effects.ts
+++ b/effect-system/effects.ts
@@ -171,13 +171,31 @@ export function createEffect<Op extends (...payload: any[]) => any>(
  *
  * let count = 0;
  * // A listener that performs orthogonal logic
- * const IOCountTXTReads = handlerFor(io.read, (path: string)=>{
+ * const IOCountTXTReads = handlerFor(io.read, (path: string) => {
  *   if(path.endsWith(".txt")) {
- *     count += 1
+ *     count += 1;
  *   }
- *   return Handler.continue(path)
+ *   return Handler.continue(path);
  * })
  *
+ * ```
+ *
+ * @example Handler cleanup with `Symbol.dispose` and `Symbol.asyncDispose`
+ *
+ * Handlers can receive a `Symbol.dispose` or `Symbol.asyncDispose` to attach cleanup logic to the {@linkcode HandlerScope} using the handler.
+ *
+ * ```ts
+ * let count = 0;
+ *
+ * const handleIORead = handlerFor(io.read, (path: string) => {
+ *   if(path.endsWith(".txt")) {
+ *     count += 1;
+ *   }
+ *   return Handler.continue(path);
+ * });
+ * handleIORead[Symbol.dispose] = () => {
+ *   count = 0;
+ * }
  * ```
  *
  * @param effect The effect we're implementing a handler for

--- a/effect-system/handlers.ts
+++ b/effect-system/handlers.ts
@@ -4,6 +4,7 @@ import {
   MissingTerminalHandlerError,
   UnhandledEffectError,
 } from "./errors.ts";
+import type { Plugin } from "./mod.ts";
 
 /**
  * @internal
@@ -201,44 +202,81 @@ export class HandlerScope {
   /**
    * Creates a new {@linkcode HandlerScope}
    *
-   * @param handlers {@linkcode Handler Handlers} to add to this scope
+   * @param handlers {@linkcode Handler Handlers} or {@linkcode Plugin Plugins} to append to this scope
    *
    * @see {@linkcode addHandlers}
    */
-  constructor(...handlers: Handlers) {
+  constructor(...handlers: (Handler<any, any> | Plugin)[]) {
     const currentScope = handlerScopes.at(-1);
     this.#parent = currentScope;
     handlerScopes.push(this);
 
-    if (handlers.length) {
-      this.addHandlers(...handlers);
+    for (const handler of handlers) {
+      if (handler instanceof Handler) {
+        this.addHandler(handler, "end");
+        continue;
+      }
+
+      for (const pluginHandler of handler.handlers) {
+        this.addHandler(pluginHandler, "end");
+      }
+
+      if (handler?.onDispose) {
+        this.onDispose(handler.onDispose);
+      }
     }
   }
 
   /**
-   * Registers handlers in the {@linkcode HandlerScope} instance
+   * Prepends handlers to the {@linkcode HandlerScope}
    *
-   * @param handlers Handlers to register
+   * @param handlers Handlers to prepend
+   *
+   * @see {@linkcode addHandler}
    *
    * @internal
    */
   addHandlers(...handlers: Handlers) {
     assert(!this.#disposed, "Can't add handlers to a disposed HandlerScope");
 
-    const handlersById = Object.groupBy(handlers, ({ id }) => id);
-    const handlersEntries = Object.entries(handlersById)
-      .filter(([_k, v]) => v !== undefined)
-      .map(([key, _handlers]): [string, Handler<any, any>[]] => {
-        return [key, _handlers!];
-      });
-
-    for (let [id, _handlers] of handlersEntries) {
-      const currentHandler = this.handlers.get(id);
-      _handlers = currentHandler ? [..._handlers, currentHandler] : _handlers;
-
-      const newHandler = Handler.fold(_handlers);
-      this.handlers.set(id, newHandler);
+    for (const handler of handlers) {
+      this.addHandler(handler);
     }
+  }
+
+  /**
+   * Adds an effect handler to the current {@linkcode HandlerScope}
+   *
+   * Most of the time you want to prepend handlers in order to override, decorate or delegate to other handlers. Use `position = "start"` to prepend a handler.
+   *
+   * Sometimes you may have a dynamically defined terminal handler for example. In that case, append the handler using `position = "end"`
+   *
+   * Looping over handlers is another use-case for `position="end"` to preserve the order
+   *
+   * @param handler The {@linkcode Handler} to add
+   * @param position Whether to add the handler at the start or end of the sequence of handlers
+   * @default "start"
+   */
+  addHandler(
+    handler: Handler<any, any>,
+    position: "start" | "end" = "start",
+  ): void {
+    assert(!this.#disposed, "Can't add a handler to a disposed HandlerScope");
+
+    const { id } = handler;
+    const currentHandler = this.handlers.get(id);
+
+    if (!currentHandler) {
+      this.handlers.set(id, handler);
+      return;
+    }
+
+    const handlers = position === "start"
+      ? [handler, currentHandler]
+      : [currentHandler, handler];
+
+    const newHandler = Handler.fold(handlers);
+    this.handlers.set(id, newHandler);
   }
 
   /**
@@ -372,11 +410,11 @@ export const Snapshot = (): () => HandlerScope => {
 };
 
 /**
- * Adds handlers to the current {@linkcode HandlersScope}
+ * Appends handlers to the current {@linkcode HandlersScope}
  *
- * @param handlers Any number of handlers to add to the current scope
+ * @param handlers Any number of handlers to append to the current scope
  *
- * @throws {MissingHandlerScopeError} It there is no {@linkcode HandlerScope} to register handlers to
+ * @throws {MissingHandlerScopeError} If there is no {@linkcode HandlerScope} to append handlers to
  */
 export const addHandlers = (...handlers: Handlers): void => {
   const currentScope = handlerScopes.at(-1);

--- a/effect-system/mod.ts
+++ b/effect-system/mod.ts
@@ -104,9 +104,9 @@ export {
 export { createState, type StateOps } from "./state.ts";
 
 /**
- * An effect plugin is a named list of handlers with an optional cleanup function
+ * An effect plugin is a named list of handlers with an optional `[Symbol.dispose]` cleanup method
  */
-export type Plugin = {
+export interface Plugin {
   /**
    * The name of the plugin
    */
@@ -115,11 +115,7 @@ export type Plugin = {
    * The list of handlers related to a service or effect
    */
   handlers: Handlers;
-  /**
-   * Optional cleanup to run when leaving the scope
-   */
-  onDispose?: () => void | PromiseLike<void>;
-};
+}
 
 /**
  * The polymorphic identity

--- a/effect-system/mod.ts
+++ b/effect-system/mod.ts
@@ -22,9 +22,9 @@
  *
  * See {@linkcode Snapshot} and {@linkcode createState}
  *
- * ## Zero-effort Plugin API
+ * ## Out-of-the-box Plugin API
  *
- * As a bonus, you get a plugin API out of the box: define your own effects and handlers, and allow consumers to extend and override them with their own handlers to suit their needs. This provides flexibility and a high level of control to your users
+ * As a bonus, you get a {@linkcode Plugin} API out-of-the-box: define your own effects and handlers, and allow consumers to extend and override them with their own handlers to suit their needs. This provides flexibility and a high level of control to your users.
  *
  * @example Create a new effect
  *
@@ -88,6 +88,28 @@
  * }
  * ```
  *
+ * @example Create a plugin
+ *
+ * Export your handlers as a {@linkcode Plugin} for the reusability of related functionality. The {@linkcode HandlerScope} constructor also accepts plugins as arguments.
+ *
+ * ```ts
+ * const pluginIO = {
+ *   name: "plugin-io",
+ *   handlers: [handleIORead, handleIOTransform, handleIOWrite]
+ * };
+ *
+ * // Usage
+ * {
+ *  using _ = new HandlerScope(pluginIO);
+ *
+ *  const content = await io.read("/path/to/input");
+ *  const transformed = await io.transform(content);
+ *  await io.write("/path/to/output", transformed);
+ *  // logs "writing to /path/to/output: MY CONTENT"
+ * }
+ *
+ * ```
+ *
  * @module
  */
 
@@ -104,7 +126,7 @@ export {
 export { createState, type StateOps } from "./state.ts";
 
 /**
- * An effect plugin is a named list of handlers with an optional `[Symbol.dispose]` cleanup method
+ * A plugin is a named list of handlers
  */
 export interface Plugin {
   /**

--- a/effect-system/mod.ts
+++ b/effect-system/mod.ts
@@ -91,6 +91,8 @@
  * @module
  */
 
+import type { Handlers } from "./handlers.ts";
+
 export { createEffect, type Effect, handlerFor } from "./effects.ts";
 export {
   addHandlers,
@@ -100,6 +102,24 @@ export {
   Snapshot,
 } from "./handlers.ts";
 export { createState, type StateOps } from "./state.ts";
+
+/**
+ * An effect plugin is a named list of handlers with an optional cleanup function
+ */
+export type Plugin = {
+  /**
+   * The name of the plugin
+   */
+  name: string;
+  /**
+   * The list of handlers related to a service or effect
+   */
+  handlers: Handlers;
+  /**
+   * Optional cleanup to run when leaving the scope
+   */
+  onDispose?: () => void | PromiseLike<void>;
+};
 
 /**
  * The polymorphic identity

--- a/effect-system/tests/setup.test.ts
+++ b/effect-system/tests/setup.test.ts
@@ -1,4 +1,4 @@
-import { createEffect, Handler, handlerFor } from "../mod.ts";
+import { createEffect, Handler, handlerFor, type Plugin } from "../mod.ts";
 
 /**
  * Console
@@ -21,9 +21,17 @@ export const logs: string[] = [];
 /**
  * @internal
  */
-export const handleConsole = handlerFor(Console.log, (message: string) => {
+const handleConsole = handlerFor(Console.log, (message: string) => {
   logs.push(message);
 });
+
+export const pluginConsole: Plugin = {
+  name: "plugin-console",
+  handlers: [handleConsole],
+  onDispose: () => {
+    logs.length = 0;
+  },
+};
 
 /**
  * State

--- a/effect-system/tests/setup.test.ts
+++ b/effect-system/tests/setup.test.ts
@@ -24,13 +24,13 @@ export const logs: string[] = [];
 const handleConsole = handlerFor(Console.log, (message: string) => {
   logs.push(message);
 });
+handleConsole[Symbol.dispose] = () => {
+  logs.length = 0;
+};
 
 export const pluginConsole: Plugin = {
   name: "plugin-console",
   handlers: [handleConsole],
-  onDispose: () => {
-    logs.length = 0;
-  },
 };
 
 /**

--- a/effect-system/tests/setup.test.ts
+++ b/effect-system/tests/setup.test.ts
@@ -1,4 +1,5 @@
-import { createEffect, Handler, handlerFor, type Plugin } from "../mod.ts";
+import { createEffect, Handler, handlerFor } from "../mod.ts";
+import { delay } from "@std/async";
 
 /**
  * Console
@@ -21,16 +22,11 @@ export const logs: string[] = [];
 /**
  * @internal
  */
-const handleConsole = handlerFor(Console.log, (message: string) => {
+export const handleConsole = handlerFor(Console.log, (message: string) => {
   logs.push(message);
 });
 handleConsole[Symbol.dispose] = () => {
   logs.length = 0;
-};
-
-export const pluginConsole: Plugin = {
-  name: "plugin-console",
-  handlers: [handleConsole],
 };
 
 /**
@@ -126,3 +122,18 @@ export const handleIoReadTXT = handlerFor(io.readFile, (path: string) => {
 export const handleIOReadBase = handlerFor(io.readFile, () => {
   return "file content";
 });
+
+/**
+ * Server
+ */
+
+export const serverStart = createEffect<() => void>("server/start");
+
+export const handlerServerStart = handlerFor(serverStart, async () => {
+  await Console.log("Starting server...");
+});
+handlerServerStart[Symbol.asyncDispose] = async () => {
+  await Console.log("Closing server...");
+  await delay(100);
+  await Console.log("Server closed");
+};


### PR DESCRIPTION
A plugin is a simple object with a name and handlers

The `HandlerScope` constructor accepts plugins and handlers

```ts
using _ = new HandlerScope(myPlugin, myOneOffHandler);
...
```