### PR TITLE
feat(core): pass a mutable Headers object to the RouteContext

### DIFF
--- a/app/start.ts
+++ b/app/start.ts
@@ -44,7 +44,7 @@ const hooks = handlerFor(
     event.headers.set("X-Content-Type-Options", "nosniff");
 
     const ua = new UserAgent(event.request.headers.get("user-agent") ?? "");
-    // console.log("ua:", ua);
+    console.log("ua:", ua);
 
     return Handler.continue(event);
   },

--- a/core/cleanup.test.ts
+++ b/core/cleanup.test.ts
@@ -1,0 +1,17 @@
+import { describe, test } from "@std/testing/bdd";
+import { assertSpyCalls, spy } from "@std/testing/mock";
+import { HandlerScope } from "../effect-system/mod.ts";
+import { dispose, onDispose } from "./cleanup.ts";
+
+describe("cleanup", () => {
+  test("dispose runs onDispose callbacks", async () => {
+    const scope = new HandlerScope();
+    const disposeScope = async () => await scope[Symbol.asyncDispose]();
+    const disposeScopeSpy = spy(disposeScope);
+
+    onDispose(disposeScopeSpy);
+    await dispose();
+
+    assertSpyCalls(disposeScopeSpy, 1);
+  });
+});

--- a/core/deno.json
+++ b/core/deno.json
@@ -8,7 +8,8 @@
     "./plugins": "./plugins/mod.ts",
     "./plugins/router": "./plugins/router/router.ts",
     "./parser": "./parser.ts",
-    "./environment": "./environment.ts"
+    "./environment": "./environment.ts",
+    "./effect-system": "./effect-system.ts"
   },
   "imports": {
     "$effects/": "./effects/",

--- a/core/effect-system.ts
+++ b/core/effect-system.ts
@@ -1,0 +1,1 @@
+export * from "@radish/effect-system";

--- a/core/effects/router.ts
+++ b/core/effects/router.ts
@@ -5,6 +5,7 @@ export type RouteContext = {
   request: Request;
   cookies: Record<string, string>;
   url: URL;
+  headers: Headers;
   params?: URLPatternResult;
 };
 

--- a/core/effects/server.ts
+++ b/core/effects/server.ts
@@ -2,7 +2,7 @@ import { createEffect, type Effect } from "@radish/effect-system";
 
 interface Server {
   start: (
-    options:
+    options?:
       | Deno.ServeTcpOptions
       | (Deno.ServeTcpOptions & Deno.TlsCertifiedKeyPem),
   ) => void;
@@ -14,7 +14,7 @@ interface Server {
 
 export const server: {
   start: (
-    options:
+    options?:
       | Deno.ServeTcpOptions
       | (Deno.ServeTcpOptions & Deno.TlsCertifiedKeyPem),
   ) => Effect<void>;

--- a/core/plugins/hmr/hmr.ts
+++ b/core/plugins/hmr/hmr.ts
@@ -64,14 +64,17 @@ const handleHMRStart = handlerFor(hmr.start, async (): Promise<void> => {
   }
 });
 handleHMRStart[Symbol.dispose] = () => {
-  hmrEventsCache.clear();
-  watcher?.close();
-  console.log("HMR closed");
+  if (watcher) {
+    hmrEventsCache.clear();
+    watcher.close();
+    console.log("HMR closed");
+  }
 };
 
 export const pluginHMR: Plugin = {
   name: "plugin-hmr",
   handlers: [
+    handleHMRStart,
     handleHMRPipeline,
     handlerFor(hmr.update, id),
   ],

--- a/core/plugins/router/router.ts
+++ b/core/plugins/router/router.ts
@@ -8,7 +8,7 @@ import { manifestShape } from "$lib/plugins/render/hooks/manifest.ts";
 import type { MaybePromise } from "$lib/types.d.ts";
 import { createStandardResponse } from "$lib/utils/http.ts";
 import {
-  addHandlers,
+  addHandler,
   Handler,
   handlerFor,
   type Plugin,
@@ -28,7 +28,7 @@ const square_brackets_around_named_group =
  *
  * Dynamically creates and registers a handler for `router/handle-route`. If both the route method and pattern match on a given request, the provided callback runs.
  */
-export const handleAddRoute: Handler<[route: Route], void> = handlerFor(
+export const handleRouterAddRoute: Handler<[route: Route], void> = handlerFor(
   router.addRoute,
   (route) => {
     const newHandler = handlerFor(router.handleRoute, (context) => {
@@ -46,16 +46,16 @@ export const handleAddRoute: Handler<[route: Route], void> = handlerFor(
       return Handler.continue(context);
     });
 
-    addHandlers(newHandler);
+    addHandler(newHandler);
   },
 );
 
 /**
  * Default handler for `router/handle-route`
  *
- * @returns A standard 404 Not Found `text/plain` response
+ * @returns A standard 404 NotFound `text/plain` response
  */
-export const handleRouterDefaultRouteHandler: Handler<
+export const handleRouterHandleRouteTerminal: Handler<
   [context: RouteContext],
   MaybePromise<Response>
 > = handlerFor(
@@ -72,7 +72,7 @@ export const handleRouterDefaultRouteHandler: Handler<
  *
  * @performs
  * - `config/read`
- * - `build/dest`
+ * - `build/dest` Knows where to find the actual route html
  * - `manifest/get`
  * - `router/add-route`
  */
@@ -125,8 +125,8 @@ export const handleRouterInit: Handler<[], void> = handlerFor(
 export const pluginRouter: Plugin = {
   name: "plugin-router",
   handlers: [
-    handleAddRoute,
-    handleRouterDefaultRouteHandler,
+    handleRouterAddRoute,
+    handleRouterHandleRouteTerminal,
     handleRouterInit,
   ],
 };

--- a/core/plugins/server/mod.ts
+++ b/core/plugins/server/mod.ts
@@ -32,8 +32,20 @@ export const handleServerRequest = handlerFor(
     try {
       const url = new URL(request.url);
       const cookies = getCookies(request.headers);
+      const headers = new Headers();
 
-      return await router.handleRoute({ request, url, cookies });
+      const response = await router.handleRoute({
+        request,
+        url,
+        cookies,
+        headers,
+      });
+
+      for (const [name, value] of headers.entries()) {
+        response.headers.set(name, value);
+      }
+
+      return response;
     } catch (error) {
       console.error(error);
       if (error instanceof AppError) {
@@ -65,8 +77,10 @@ export const handleServerStart = handlerFor(server.start, (options) => {
   Deno.addSignalListener("SIGTERM", shutdown);
 });
 handleServerStart[Symbol.asyncDispose] = async () => {
-  await httpServer?.shutdown();
-  console.log("Server closed");
+  if (httpServer) {
+    await httpServer.shutdown();
+    console.log("Server closed");
+  }
 };
 
 const shutdown = async () => {

--- a/core/plugins/server/server.test.ts
+++ b/core/plugins/server/server.test.ts
@@ -1,0 +1,41 @@
+import { router, server } from "$effects/mod.ts";
+import { handleRouterAddRoute } from "$lib/plugins/router/router.ts";
+import { HandlerScope } from "@radish/effect-system";
+import { assertEquals } from "@std/assert/equals";
+import { describe, test } from "@std/testing/bdd";
+import { pluginServer } from "./mod.ts";
+
+describe("server", () => {
+  test("server/start: cleans-up without leaks", async () => {
+    let cleanup = 0;
+
+    {
+      await using scope = new HandlerScope(pluginServer, handleRouterAddRoute);
+      scope.onDispose(() => cleanup++);
+      await server.start({ port: 1235 });
+    }
+
+    assertEquals(cleanup, 1);
+  });
+
+  test("server/handleRequest: handles requests", async () => {
+    await using _ = new HandlerScope(pluginServer, handleRouterAddRoute);
+
+    await router.addRoute({
+      method: "GET",
+      pattern: new URLPattern({ pathname: "/about" }),
+      handleRoute: () => {
+        return new Response("hi", {
+          headers: { "content-type": "text/plain" },
+        });
+      },
+    });
+
+    await server.start({ port: 1235 });
+
+    const res = await fetch("http://localhost:1235/about");
+    const text = await res.text();
+
+    assertEquals(text, "hi");
+  });
+});

--- a/core/plugins/ws/ws.ts
+++ b/core/plugins/ws/ws.ts
@@ -1,5 +1,4 @@
 import { ws } from "$effects/ws.ts";
-import { dev } from "$lib/environment.ts";
 import { handlerFor, type Plugin } from "@radish/effect-system";
 import { handleInsertWebSocketScript } from "./hooks/render.route.ts";
 import { handleWSServerRequest } from "./hooks/server.handle-request.ts";
@@ -33,11 +32,11 @@ const handleWSHandleSocket = handlerFor(ws.handleSocket, (socket) => {
   });
 });
 handleWSHandleSocket[Symbol.dispose] = () => {
-  if (clients) {
+  if (clients.size) {
     for (const client of clients) client.close();
     clients.clear();
 
-    if (dev) console.log("WebSocket connection closed");
+    console.log("WebSocket connection closed");
   }
 };
 

--- a/core/start.ts
+++ b/core/start.ts
@@ -37,7 +37,7 @@ export async function startApp(
 ) {
   const plugins = config.plugins ?? [];
   const scope = new effects.HandlerScope(...plugins);
-  onDispose(scope[Symbol.asyncDispose]);
+  onDispose(async () => await scope[Symbol.asyncDispose]());
 
   config = await configEffect.transform({ ...config, args: cliArgs });
   const resolvedConfig: Config = Object.freeze(config);

--- a/core/types.d.ts
+++ b/core/types.d.ts
@@ -1,4 +1,3 @@
-import type { Plugin } from "@radish/effect-system";
 import type { SpeculationRules } from "./generate/speculationrules.ts";
 import type { ImportMapOptions } from "./plugins/importmap/importmap.ts";
 
@@ -25,10 +24,6 @@ export interface Config {
     envPath?: string;
   };
   importmap?: ImportMapOptions;
-  /**
-   * Array of plugins to use
-   */
-  plugins?: Plugin[];
   router?: {
     /**
      * An object mapping matcher names to their corresponding regexp definition.

--- a/effect-system/handlers.ts
+++ b/effect-system/handlers.ts
@@ -323,7 +323,7 @@ export class HandlerScope {
    *
    * @internal
    */
-  [Symbol.dispose]() {
+  [Symbol.dispose] = () => {
     if (this.#disposed) return;
 
     handlerScopes.pop();
@@ -331,20 +331,20 @@ export class HandlerScope {
     this.#stack.dispose();
     this.#parent = undefined;
     this.#disposed = true;
-  }
+  };
 
   /**
    * Asynchronously cleans up the {@linkcode HandlerScope} and restores its parent scope as the current scope
    *
    * @internal
    */
-  async [Symbol.asyncDispose]() {
+  [Symbol.asyncDispose] = async () => {
     if (!this.#disposed) {
       this[Symbol.dispose]();
 
       await this.#asyncStack.disposeAsync();
     }
-  }
+  };
 }
 
 /**

--- a/effect-system/handlers.ts
+++ b/effect-system/handlers.ts
@@ -235,23 +235,6 @@ export class HandlerScope {
   }
 
   /**
-   * Prepends handlers to the {@linkcode HandlerScope}
-   *
-   * @param handlers Handlers to prepend
-   *
-   * @see {@linkcode addHandler}
-   *
-   * @internal
-   */
-  addHandlers(...handlers: Handlers) {
-    assert(!this.#disposed, "Can't add handlers to a disposed HandlerScope");
-
-    for (const handler of handlers) {
-      this.addHandler(handler);
-    }
-  }
-
-  /**
    * Adds an effect handler to the current {@linkcode HandlerScope}
    *
    * Most of the time you want to prepend handlers in order to override, decorate or delegate to other handlers. Use `position = "start"` to prepend a handler.
@@ -437,15 +420,26 @@ export const Snapshot = (): () => HandlerScope => {
 };
 
 /**
- * Appends handlers to the current {@linkcode HandlersScope}
+ * Adds an effect handler to the current {@linkcode HandlerScope}
  *
- * @param handlers Any number of handlers to append to the current scope
+ * Most of the time you want to prepend handlers in order to override, decorate or delegate to other handlers. Use `position = "start"` to prepend a handler.
  *
- * @throws {MissingHandlerScopeError} If there is no {@linkcode HandlerScope} to append handlers to
+ * Sometimes you may for example have a dynamically defined terminal handler. In that case, append the handler using `position = "end"`
+ *
+ * Looping over handlers for the same effect is another use-case for `position="end"` to preserve their order
+ *
+ * @param handler The {@linkcode Handler} to add
+ * @param position Whether to add the handler at the start or end of the sequence of handlers
+ * @default "start"
+ *
+ * @throws {MissingHandlerScopeError} If there is no {@linkcode HandlerScope} to add handlers to
  */
-export const addHandlers = (...handlers: Handlers): void => {
+export const addHandler = (
+  handler: Handler<any, any>,
+  position: "start" | "end" = "start",
+): void => {
   const currentScope = handlerScopes.at(-1);
   if (!currentScope) throw new MissingHandlerScopeError();
 
-  currentScope.addHandlers(...handlers);
+  currentScope.addHandler(handler, position);
 };

--- a/effect-system/handlers.ts
+++ b/effect-system/handlers.ts
@@ -323,7 +323,7 @@ export class HandlerScope {
    *
    * @internal
    */
-  [Symbol.dispose] = () => {
+  [Symbol.dispose] = (): void => {
     if (this.#disposed) return;
 
     handlerScopes.pop();
@@ -338,7 +338,7 @@ export class HandlerScope {
    *
    * @internal
    */
-  [Symbol.asyncDispose] = async () => {
+  [Symbol.asyncDispose] = async (): Promise<void> => {
     if (!this.#disposed) {
       this[Symbol.dispose]();
 

--- a/effect-system/mod.ts
+++ b/effect-system/mod.ts
@@ -117,7 +117,7 @@ import type { Handlers } from "./handlers.ts";
 
 export { createEffect, type Effect, handlerFor } from "./effects.ts";
 export {
-  addHandlers,
+  addHandler,
   Handler,
   type Handlers,
   HandlerScope,

--- a/effect-system/state.ts
+++ b/effect-system/state.ts
@@ -108,7 +108,9 @@ export const createState = <T>(key: string, initialValue?: T): {
     }),
   ];
 
-  scope.addHandlers(...handlers);
+  for (const handler of handlers) {
+    scope.addHandler(handler);
+  }
 
   return {
     get,

--- a/effect-system/tests/effects.test.ts
+++ b/effect-system/tests/effects.test.ts
@@ -1,3 +1,4 @@
+import { assertSpyCalls, spy } from "@std/testing/mock";
 import {
   assertEquals,
   assertGreaterOrEqual,
@@ -74,6 +75,28 @@ describe("effect system", () => {
     }
 
     assertEquals(logs, ["clean"]);
+  });
+
+  test("HandlerScope Symbol.dispose is lexically bound", () => {
+    const resources = new DisposableStack();
+    const scope = new HandlerScope();
+
+    const disposeSpy = spy(scope[Symbol.dispose]);
+    resources.defer(disposeSpy);
+    resources.dispose();
+
+    assertSpyCalls(disposeSpy, 1);
+  });
+
+  test("HandlerScope Symbol.asyncDispose function is lexically bound", async () => {
+    const resources = new AsyncDisposableStack();
+    const scope = new HandlerScope();
+
+    const asyncDisposeSpy = spy(scope[Symbol.asyncDispose]);
+    resources.defer(asyncDisposeSpy);
+    await resources.disposeAsync();
+
+    assertSpyCalls(asyncDisposeSpy, 1);
   });
 
   test("handler cleanup", async () => {

--- a/effect-system/tests/effects.test.ts
+++ b/effect-system/tests/effects.test.ts
@@ -13,8 +13,8 @@ import {
   MissingTerminalHandlerError,
   UnhandledEffectError,
 } from "../errors.ts";
-import { addHandlers, Handler, handlerScopes } from "../handlers.ts";
-import { HandlerScope, id } from "../mod.ts";
+import { Handler, handlerScopes } from "../handlers.ts";
+import { addHandler, HandlerScope, id } from "../mod.ts";
 import {
   Console,
   createState,
@@ -172,7 +172,7 @@ describe("effect system", () => {
 
   test("dynamic handling", async () => {
     using _ = new HandlerScope();
-    addHandlers(handleIoReadTXT);
+    addHandler(handleIoReadTXT);
 
     const txt = await io.readFile("note.txt");
     assertEquals(txt, "txt content");
@@ -180,7 +180,7 @@ describe("effect system", () => {
 
   test("dynamic delegation", async () => {
     using _ = new HandlerScope(handleIOReadBase);
-    addHandlers(handleIoReadTXT);
+    addHandler(handleIoReadTXT);
 
     const txt = await io.readFile("note.txt");
     assertEquals(txt, "txt content");
@@ -191,7 +191,7 @@ describe("effect system", () => {
 
   test("unscoped dynamic handling", () => {
     try {
-      addHandlers(handleIoReadTXT);
+      addHandler(handleIoReadTXT);
       unreachable();
     } catch (error) {
       assertInstanceOf(error, MissingHandlerScopeError);


### PR DESCRIPTION
And adjust the `start.ts` script to benefit from the fibered structure of HandlerScopes, allowing users hooks' to decorate the dynamically generated routes. To to so, just create a new scope to ensure your router/handleRoute handlers are not overriden by the dynamically generated ones

```ts
const hooks = handlerFor(
  router.handleRoute,
  (event) => {
    // Avoid mime type sniffing
    event.headers.set("X-Content-Type-Options", "nosniff");
    return Handler.continue(event);
  },
);

const rootScope = new HandlerScope(...myPlugins);
await startApp(config);

// hooks decorates the dynamically generated routes
const _ = new HandlerScope(hooks);
if (dev) await hmr.start();
``` 