### PR TITLE
feat(init): add github & local install methods

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -44,6 +44,7 @@
     "@std/cli": "jsr:@std/cli@^1.0.17",
     "@std/collections": "jsr:@std/collections@^1.0.11",
     "@std/dotenv": "jsr:@std/dotenv@^0.225.3",
+    "@std/encoding": "jsr:@std/encoding@^1.0.10",
     "@std/fmt": "jsr:@std/fmt@^1.0.7",
     "@std/fs": "jsr:@std/fs@^1.0.17",
     "@std/http": "jsr:@std/http@^1.0.15",


### PR DESCRIPTION
Adds two other ways to init a project:
- locally if you have the init folder on disk
- from github to try the latest unreleased version

```sh
❯ deno run -A ../radish/init/mod.ts
```

Also started to abstract over the network and files operations to allow testing the init process