### PR TITLE
feat(runtime): add a fallback branch to `r-show`

### DIFF
--- a/app/elements/r-show/r-show.html
+++ b/app/elements/r-show/r-show.html
@@ -9,7 +9,7 @@
         display: contents;
       }
 
-      & > slot[name="else"] {
+      & > slot[name="fallback"] {
         display: none;
       }
     }
@@ -19,11 +19,11 @@
         display: none;
       }
 
-      & > slot[name="else"] {
+      & > slot[name="fallback"] {
         display: contents;
       }
     }
   </style>
   <slot></slot>
-  <slot name="else"></slot>
+  <slot name="fallback"></slot>
 </template>

--- a/app/elements/r-show/r-show.ts
+++ b/app/elements/r-show/r-show.ts
@@ -5,7 +5,7 @@ import { HandlerRegistry } from "@radish/runtime";
 
 export class RShow extends HandlerRegistry {
   #internals: ElementInternals;
-  if = signal(false);
+  when = signal(false);
 
   constructor() {
     super();
@@ -16,7 +16,7 @@ export class RShow extends HandlerRegistry {
     super.connectedCallback();
 
     this.effect(() => {
-      if (this.if.value) {
+      if (this.when.value) {
         this.#internals.states.add("show");
       } else {
         this.#internals.states.delete("show");

--- a/app/routes/structural-elements/r-show/index.html
+++ b/app/routes/structural-elements/r-show/index.html
@@ -5,8 +5,8 @@
     </label>
   </div>
 
-  <r-show prop:if="condition">
-    <div data-testid="if">displayed</div>
-    <div slot="else" data-testid="else">fallback</div>
+  <r-show prop:when="condition">
+    <div data-testid="content">displayed</div>
+    <div slot="fallback" data-testid="fallback">fallback</div>
   </r-show>
 </handle-show>

--- a/app/tests/structural-elements/r-show/r-show.spec.ts
+++ b/app/tests/structural-elements/r-show/r-show.spec.ts
@@ -9,11 +9,11 @@ test("r-show toggles its content", async ({ page }) => {
 
   // Content is initially visible
   await expect(checkbox).toBeChecked();
-  await expect(page.getByTestId("if")).toBeVisible();
-  await expect(page.getByTestId("else")).toBeHidden();
+  await expect(page.getByTestId("content")).toBeVisible();
+  await expect(page.getByTestId("fallback")).toBeHidden();
 
   // Clicking the checkbox toggles the content
   await checkbox.click();
-  await expect(page.getByTestId("if")).toBeHidden();
-  await expect(page.getByTestId("else")).toBeVisible();
+  await expect(page.getByTestId("content")).toBeHidden();
+  await expect(page.getByTestId("fallback")).toBeVisible();
 });


### PR DESCRIPTION
Adds a convenience fallback for simpler cases

```html
<r-show prop:when="condition">
    <div>displayed when the condition is true</div>
    <div slot="fallback">fallback dispalyed when the condition is false</div>
</r-show>
```