### PR TITLE
feat(runtime): add `r-switch` element

### DIFF
--- a/app/elements/r-match/r-match.html
+++ b/app/elements/r-match/r-match.html
@@ -1,0 +1,12 @@
+<template shadowrootmode="open">
+  <style>
+    :host(:state(match)) {
+      display: contents;
+    }
+
+    :host(:not(:state(match))) {
+      display: none;
+    }
+  </style>
+  <slot></slot>
+</template>

--- a/app/elements/r-match/r-match.ts
+++ b/app/elements/r-match/r-match.ts
@@ -1,0 +1,30 @@
+import { signal } from "@preact/signals-core";
+import { HandlerRegistry } from "@radish/runtime";
+
+// TODO: to avoid the hydration flash, set a  attribute on the server for client-rendered r-show
+
+export class RMatch extends HandlerRegistry {
+  #internals: ElementInternals;
+  when = signal(false);
+
+  constructor() {
+    super();
+    this.#internals = this.attachInternals();
+  }
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+
+    this.effect(() => {
+      if (this.when.value) {
+        this.#internals.states.add("match");
+      } else {
+        this.#internals.states.delete("match");
+      }
+    });
+  }
+}
+
+if (window && !customElements.get("r-match")) {
+  customElements.define("r-match", RMatch);
+}

--- a/app/elements/r-switch/r-switch.html
+++ b/app/elements/r-switch/r-switch.html
@@ -1,0 +1,29 @@
+<template shadowrootmode="open">
+  <style>
+    :host {
+      display: contents;
+    }
+
+    :host(:state(match)) {
+      & > slot:not([name]) {
+        display: contents;
+      }
+
+      & > slot[name="fallback"] {
+        display: none;
+      }
+    }
+
+    :host(:not(:state(match))) {
+      & > slot:not([name]) {
+        display: none;
+      }
+
+      & > slot[name="fallback"] {
+        display: contents;
+      }
+    }
+  </style>
+  <slot></slot>
+  <slot name="fallback"></slot>
+</template>

--- a/app/elements/r-switch/r-switch.ts
+++ b/app/elements/r-switch/r-switch.ts
@@ -1,0 +1,31 @@
+import { HandlerRegistry } from "@radish/runtime";
+import type { RMatch } from "../r-match/r-match.ts";
+
+// TODO: to avoid the hydration flash, set a  attribute on the server for client-rendered r-show
+
+export class RSwitch extends HandlerRegistry {
+  #internals: ElementInternals;
+
+  constructor() {
+    super();
+    this.#internals = this.attachInternals();
+  }
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+
+    this.effect(() => {
+      const matches = [...this.querySelectorAll<RMatch>("& > r-match")];
+
+      if (matches.some((m) => m.when.value)) {
+        this.#internals.states.add("match");
+      } else {
+        this.#internals.states.delete("match");
+      }
+    });
+  }
+}
+
+if (window && !customElements.get("r-switch")) {
+  customElements.define("r-switch", RSwitch);
+}

--- a/app/routes/structural-elements/r-switch/demo-switch.ts
+++ b/app/routes/structural-elements/r-switch/demo-switch.ts
@@ -1,0 +1,11 @@
+import { HandlerRegistry, signal } from "@radish/runtime";
+
+export class DemoSwitch extends HandlerRegistry {
+  condition1 = signal(true);
+  condition2 = signal(false);
+  condition3 = signal(false);
+}
+
+if (window && !customElements.get("demo-switch")) {
+  customElements.define("demo-switch", DemoSwitch);
+}

--- a/app/routes/structural-elements/r-switch/index.html
+++ b/app/routes/structural-elements/r-switch/index.html
@@ -1,0 +1,33 @@
+<demo-switch>
+  <div>
+    <label>
+      <input name="tab" type="checkbox" bind:checked="condition1"> tab 1
+    </label>
+    <label>
+      <input name="tab" type="checkbox" bind:checked="condition2"> tab 2
+    </label>
+    <label>
+      <input name="tab" type="checkbox" bind:checked="condition3"> tab 3
+    </label>
+  </div>
+
+  <!-- Fallback only -->
+  <r-switch data-testid="fallback-only">
+    <div slot="fallback">fallback only</div>
+  </r-switch>
+
+  <!-- Only r-match children can match  -->
+  <r-switch data-testid="r-match-only">
+    <div>not matching</div>
+    <div slot="fallback">fallback only</div>
+  </r-switch>
+
+  <!-- Switches between matching groups -->
+  <r-switch data-testid="switch-and-fallthrough">
+    <r-match prop:when="condition1">content 1</r-match>
+    <r-match prop:when="condition2">content 2</r-match>
+    <r-match prop:when="condition3">content 3</r-match>
+
+    <div slot="fallback">fallback</div>
+  </r-switch>
+</demo-switch>

--- a/app/tests/structural-elements/r-switch/r-switch.spec.ts
+++ b/app/tests/structural-elements/r-switch/r-switch.spec.ts
@@ -1,0 +1,78 @@
+import { expect, type Page, test } from "playwright/test";
+
+test.describe("r-switch", () => {
+  let page: Page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+
+    const res =
+      await (page.goto("http://localhost:1235/structural-elements/r-switch"));
+    expect(res?.status()).toBe(200);
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test("fallback-only r-switch displays the fallback", async () => {
+    const fallback = page
+      .getByTestId("fallback-only")
+      .locator("[slot=fallback]");
+
+    await expect(fallback).toBeVisible();
+  });
+
+  test("only r-match children of fallback content can be visible", async () => {
+    const testCase = page.getByTestId("r-match-only");
+    const notVisible = testCase.locator("> div:not([slot=fallback])");
+    const fallback = testCase.locator("[slot=fallback]");
+
+    await expect(notVisible).toBeHidden();
+    await expect(fallback).toBeVisible();
+  });
+
+  test("switches between matches and allows fallthrough", async () => {
+    const checkbox1 = page.getByLabel("tab 1");
+    const checkbox2 = page.getByLabel("tab 2");
+    const checkbox3 = page.getByLabel("tab 3");
+
+    // Checkbox 1 is checked
+    await expect(checkbox1).toBeChecked();
+    await expect(checkbox2).not.toBeChecked();
+    await expect(checkbox3).not.toBeChecked();
+
+    const testCase = page.getByTestId("switch-and-fallthrough");
+    const match1 = testCase.locator("> r-match:nth-of-type(1)");
+    const match2 = testCase.locator("> r-match:nth-of-type(2)");
+    const match3 = testCase.locator("> r-match:nth-of-type(3)");
+    const fallback = testCase.locator("[slot=fallback]");
+
+    // Case 1 matches
+    await expect(match1).toBeVisible();
+    await expect(match2).toBeHidden();
+    await expect(match3).toBeHidden();
+    await expect(fallback).toBeHidden();
+
+    // Fallback
+    await checkbox1.click();
+    await expect(match1).toBeHidden();
+    await expect(match2).toBeHidden();
+    await expect(match3).toBeHidden();
+    await expect(fallback).toBeVisible();
+
+    // Case 2 matches only
+    await checkbox2.click();
+    await expect(match1).toBeHidden();
+    await expect(match2).toBeVisible();
+    await expect(match3).toBeHidden();
+    await expect(fallback).toBeHidden();
+
+    // Fallthrough
+    await checkbox3.click();
+    await expect(match1).toBeHidden();
+    await expect(match2).toBeVisible();
+    await expect(match3).toBeVisible();
+    await expect(fallback).toBeHidden();
+  });
+});

--- a/core/plugins/render/directives/mod.ts
+++ b/core/plugins/render/directives/mod.ts
@@ -24,6 +24,10 @@ export const handleDirectiveBase = handlerFor(
   },
 );
 
+/**
+ * @hooks
+ * - `render/directive`
+ */
 export const handleDirectives = [
   handleAttrDirective,
   handleBindDirective,

--- a/core/plugins/render/hooks/build.sort.ts
+++ b/core/plugins/render/hooks/build.sort.ts
@@ -63,6 +63,9 @@ const sortComponents = <T extends ElementManifest | RouteManifest>(
 };
 
 /**
+ * @hooks
+ * - `build/sort`
+ *
  * @performs
  * - `manifest/get`
  */
@@ -116,7 +119,7 @@ export const handleSort = handlerFor(
             continue;
           }
 
-          unreachable(`Entry not handled by sortFiled '${entry.path}'`);
+          unreachable(`Entry not handled by sortFile '${entry.path}'`);
         } else {
           otherEntries.push(entry);
         }

--- a/core/plugins/render/hooks/build.transform.ts
+++ b/core/plugins/render/hooks/build.transform.ts
@@ -10,6 +10,9 @@ import { assertEmptyHandlerRegistryStack } from "../state.ts";
 import { manifestShape } from "./manifest.ts";
 
 /**
+ * @hooks
+ * - `build/transform`
+ *
  * @performs
  * - `manifest/get`
  * - `render/component`

--- a/core/plugins/render/hooks/hmr.update.ts
+++ b/core/plugins/render/hooks/hmr.update.ts
@@ -10,6 +10,9 @@ import { updateManifest } from "../../manifest/manifest.ts";
 import { manifestShape } from "./manifest.ts";
 
 /**
+ * @hooks
+ * - `hmr/update`
+ *
  * @performs
  * - `manifest/get`
  * - `manifest/update`

--- a/core/plugins/render/hooks/manifest.ts
+++ b/core/plugins/render/hooks/manifest.ts
@@ -25,6 +25,7 @@ export const manifestShape = {
 /**
  * @hooks
  * - `io/write` Inserts parser imports in the generated manifest module
+ * - `manifest/update`
  *
  * @performs
  * - `io/read`

--- a/core/plugins/render/utils/setAttribute.ts
+++ b/core/plugins/render/utils/setAttribute.ts
@@ -12,8 +12,10 @@ export const setAttribute = (
     "Can only set primitive values as attributes",
   );
 
-  if (booleanAttributes.includes(attribute) && value) {
-    attributes.push([attribute, ""]);
+  if (booleanAttributes.includes(attribute)) {
+    if (value) {
+      attributes.push([attribute, ""]);
+    }
   } else {
     attributes.push([attribute, `${value}`]);
   }


### PR DESCRIPTION
For more complex cases than `r-show`. Fallthrough is allowed for overlapping conditions

```html
<r-switch>
  <r-match prop:when="condition1">content 1</r-match>
  <r-match prop:when="condition2">content 2</r-match>
  <r-match prop:when="condition3">content 3</r-match>

  <div slot="fallback">fallback</div>
</r-switch>
```