### PR TITLE
perf(core): only override manifest/load once

### DIFF
--- a/core/plugins/render/hooks/manifest/manifest.load.ts
+++ b/core/plugins/render/hooks/manifest/manifest.load.ts
@@ -3,7 +3,7 @@ import { handlerFor } from "@radish/effect-system";
 import { manifestShape } from "./mod.ts";
 
 /**
- * Ensures the manifest has the shape expected by the render plugin
+ * Ensures the manifest has the shape the render plugin expects
  *
  * @hooks
  * - `manifest/load`
@@ -20,5 +20,5 @@ export const handleManifestLoadRenderHook = handlerFor(
     await manifest.set(manifestObject);
     return manifestObject;
   },
-  { reentrant: false },
+  { reentrant: false, once: true },
 );


### PR DESCRIPTION
the manifest/load hook override of the render plugin only needs to be executed once