### PR TITLE
BREAKING(core): rename `handleRequest` and `handleRoute` to `onRequest`

### DIFF
--- a/app/start.ts
+++ b/app/start.ts
@@ -23,7 +23,7 @@ import { join } from "@std/path";
 const dirname = import.meta.dirname!;
 const clientRuntime = join(dirname, "..", "runtime", "client");
 
-const substituteDevRuntime = handlerFor(router.handleRoute, async (context) => {
+const substituteDevRuntime = handlerFor(router.onRequest, async (context) => {
   const pattern = new URLPattern({ pathname: "/@radish/runtime*" });
   const patternResult = pattern.exec(context.request.url);
 
@@ -37,7 +37,7 @@ const substituteDevRuntime = handlerFor(router.handleRoute, async (context) => {
   return Handler.continue(context);
 });
 
-const hooks = handlerFor(router.handleRoute, (event) => {
+const hooks = handlerFor(router.onRequest, (event) => {
   // Avoid mime type sniffing
   event.headers.set("X-Content-Type-Options", "nosniff");
 

--- a/core/effects/router.ts
+++ b/core/effects/router.ts
@@ -12,13 +12,13 @@ export type RouteContext = {
 export type Route = {
   method: string | string[];
   pattern: URLPattern;
-  handleRoute: (context: RouteContext) => MaybePromise<Response>;
+  onRequest: (context: RouteContext) => MaybePromise<Response>;
 };
 
 interface RouterOps {
   init: () => void;
   addRoute: (route: Route) => void;
-  handleRoute: (context: RouteContext) => MaybePromise<Response>;
+  onRequest: (context: RouteContext) => MaybePromise<Response>;
 }
 
 export const router: {
@@ -33,9 +33,9 @@ export const router: {
   /**
    * Handles a requested route
    */
-  handleRoute: (context: RouteContext) => Effect<MaybePromise<Response>>;
+  onRequest: (context: RouteContext) => Effect<MaybePromise<Response>>;
 } = {
   init: createEffect<RouterOps["init"]>("router/init"),
   addRoute: createEffect<RouterOps["addRoute"]>("router/add-route"),
-  handleRoute: createEffect<RouterOps["handleRoute"]>("router/handle-route"),
+  onRequest: createEffect<RouterOps["onRequest"]>("router/on-request"),
 };

--- a/core/effects/server.ts
+++ b/core/effects/server.ts
@@ -6,7 +6,7 @@ interface Server {
       | Deno.ServeTcpOptions
       | (Deno.ServeTcpOptions & Deno.TlsCertifiedKeyPem),
   ) => void;
-  handleRequest: (
+  onRequest: (
     request: Request,
     info: Deno.ServeHandlerInfo,
   ) => Response;
@@ -18,11 +18,11 @@ export const server: {
       | Deno.ServeTcpOptions
       | (Deno.ServeTcpOptions & Deno.TlsCertifiedKeyPem),
   ) => Effect<void>;
-  handleRequest: (
+  onRequest: (
     request: Request,
     info: Deno.ServeHandlerInfo,
   ) => Effect<Response>;
 } = {
   start: createEffect<Server["start"]>("server/start"),
-  handleRequest: createEffect<Server["handleRequest"]>("server/handle-request"),
+  onRequest: createEffect<Server["onRequest"]>("server/on-request"),
 };

--- a/core/plugins/router/router.test.ts
+++ b/core/plugins/router/router.test.ts
@@ -111,10 +111,10 @@ describe("router", () => {
     ]);
   });
 
-  test("router/handleRoute: user hooks can decorate the dynamically generated routes", async () => {
+  test("router/onRequest: user hooks can decorate the dynamically generated routes", async () => {
     // Mutates the Headers object
     const hooks = handlerFor(
-      router.handleRoute,
+      router.onRequest,
       (event) => {
         event.headers.set("X-Content-Type-Options", "nosniff");
         if (event.url.pathname === "/") {

--- a/core/plugins/router/router.ts
+++ b/core/plugins/router/router.ts
@@ -31,7 +31,7 @@ const square_brackets_around_named_group =
 export const handleRouterAddRoute: Handler<[route: Route], void> = handlerFor(
   router.addRoute,
   (route) => {
-    const newHandler = handlerFor(router.handleRoute, (context) => {
+    const newHandler = handlerFor(router.onRequest, (context) => {
       const patternResult = route.pattern.exec(context.request.url);
 
       if (
@@ -40,7 +40,7 @@ export const handleRouterAddRoute: Handler<[route: Route], void> = handlerFor(
           ? route.method.includes(context.request.method)
           : route.method === context.request.method)
       ) {
-        return route.handleRoute({ ...context, params: patternResult });
+        return route.onRequest({ ...context, params: patternResult });
       }
 
       return Handler.continue(context);
@@ -59,7 +59,7 @@ export const handleRouterHandleRouteTerminal: Handler<
   [context: RouteContext],
   MaybePromise<Response>
 > = handlerFor(
-  router.handleRoute,
+  router.onRequest,
   () => {
     return createStandardResponse(STATUS_CODE.NotFound, {
       headers: { "Content-Type": "text/plain" },
@@ -106,7 +106,7 @@ export const handleRouterInit: Handler<[], void> = handlerFor(
       await router.addRoute({
         method: "GET",
         pattern: new URLPattern({ pathname }),
-        handleRoute: async ({ request }) => {
+        onRequest: async ({ request }) => {
           return await serveFile(request, destPath);
         },
       });

--- a/core/plugins/server/mod.ts
+++ b/core/plugins/server/mod.ts
@@ -27,14 +27,14 @@ export const SERVER_DEFAULTS: Config["server"] = {
  * - `router/handle-request`
  */
 export const handleServerRequest = handlerFor(
-  server.handleRequest,
+  server.onRequest,
   async (request) => {
     try {
       const url = new URL(request.url);
       const cookies = getCookies(request.headers);
       const headers = new Headers();
 
-      const response = await router.handleRoute({
+      const response = await router.onRequest({
         request,
         url,
         cookies,
@@ -72,7 +72,7 @@ export const handleServerStart = handlerFor(server.start, (options) => {
   httpServer = Deno.serve(
     { ...SERVER_DEFAULTS, ...options },
     async (request, info) => {
-      return await server.handleRequest(request, info);
+      return await server.onRequest(request, info);
     },
   );
 
@@ -107,7 +107,7 @@ const shutdown = async () => {
  * await router.addRoute({
  *   method: "GET",
  *   pattern: new URLPattern({ pathname: "/about" }),
- *   handleRoute: () => {
+ *   onRequest: () => {
  *     return new Response("hi", {
  *       headers: { "content-type": "text/plain" },
  *     });

--- a/core/plugins/server/server.test.ts
+++ b/core/plugins/server/server.test.ts
@@ -18,13 +18,13 @@ describe("server", () => {
     assertEquals(cleanup, 1);
   });
 
-  test("server/handleRequest: handles requests", async () => {
+  test("server/onRequest: handles requests", async () => {
     await using _ = new HandlerScope(pluginServer, handleRouterAddRoute);
 
     await router.addRoute({
       method: "GET",
       pattern: new URLPattern({ pathname: "/about" }),
-      handleRoute: () => {
+      onRequest: () => {
         return new Response("hi", {
           headers: { "content-type": "text/plain" },
         });

--- a/core/plugins/ws/hooks/server.handle-request.ts
+++ b/core/plugins/ws/hooks/server.handle-request.ts
@@ -10,7 +10,7 @@ import { createStandardResponse } from "$lib/utils/http.ts";
  * - `ws/handle-socket`
  */
 export const handleWSServerRequest = handlerFor(
-  server.handleRequest,
+  server.onRequest,
   async (request, info) => {
     if (!dev && request.headers.get("upgrade")) {
       // Not implemented: we don't support upgrades in production

--- a/core/start.ts
+++ b/core/start.ts
@@ -84,7 +84,7 @@ export async function startApp(config: Config) {
       await router.addRoute({
         method: "GET",
         pattern: new URLPattern({ pathname: `/${folder}/*` }),
-        handleRoute: async ({ request }) => {
+        onRequest: async ({ request }) => {
           return await serveDir(request, { fsRoot });
         },
       });

--- a/effect-system/handlers.ts
+++ b/effect-system/handlers.ts
@@ -531,7 +531,7 @@ export const Snapshot = (): () => HandlerScope => {
  * A file-based router can dynamically generate route handlers and add them to the current `HandlerScope` when scanning the file system
  *
  * ```ts
- * const newRouteHandler = handlerFor(router.handleRoute, (context) => {
+ * const newRouteHandler = handlerFor(router.onRequest, (context) => {
  *   // create the route
  * });
  *


### PR DESCRIPTION
both better describes this as a hook with `on*` and makes the connection between the `server` and `router` more explicit