### PR TITLE
refactore(runtime): revert slow-types

### DIFF
--- a/.github/workflows/deno-publish-dry.yml
+++ b/.github/workflows/deno-publish-dry.yml
@@ -21,4 +21,4 @@ jobs:
         uses: denoland/setup-deno@v2
 
       - name: Run deno publish --dry-run
-        run: deno publish --dry-run --allow-slow-types
+        run: deno publish --dry-run

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -32,7 +32,7 @@
         "no-sync-fn-in-async-fn",
         "verbatim-module-syntax"
       ],
-      "exclude": ["no-explicit-any", "ban-types", "no-slow-types"],
+      "exclude": ["no-explicit-any", "ban-types"],
       "tags": ["jsr", "recommended"]
     }
   },

--- a/runtime/src/types.d.ts
+++ b/runtime/src/types.d.ts
@@ -1,33 +1,7 @@
-import type { HandlerRegistry } from "./handler-registry.ts";
-
-export type TypedEvent<T extends EventTarget, Detail> = CustomEvent<Detail> & {
-  target: T;
-};
-
-type HandlerRegistryEvent<D> = TypedEvent<HandlerRegistry, D>;
-
-export interface HandleDirectiveEventDetail {
+export interface DirectiveEventDetail {
   target: EventTarget;
   identifier: string;
   key: string;
-}
-
-export type HandleDirectiveEvent = HandlerRegistryEvent<
-  HandleDirectiveEventDetail
->;
-
-declare global {
-  interface GlobalEventHandlersEventMap {
-    "rad::attr": HandleDirectiveEvent;
-    "rad::bind": HandleDirectiveEvent;
-    "rad::bool": HandleDirectiveEvent;
-    "rad::classlist": HandleDirectiveEvent;
-    "rad::html": HandleDirectiveEvent;
-    "rad::on": HandleDirectiveEvent;
-    "rad::prop": HandleDirectiveEvent;
-    "rad::text": HandleDirectiveEvent;
-    "rad::use": HandleDirectiveEvent;
-  }
 }
 
 export interface AutonomousCustomElement {

--- a/std-elements/mod.ts
+++ b/std-elements/mod.ts
@@ -5,12 +5,13 @@
  */
 
 import { createPackage } from "@radish/core/plugins";
+import type { Plugin } from "@radish/effect-system";
 import { assertExists } from "@std/assert";
 
 const root = import.meta.dirname;
 assertExists(root);
 
-export const pluginStdElements = createPackage(
+export const pluginStdElements: Plugin = createPackage(
   "radish-std-elements-plugin",
   root,
 );


### PR DESCRIPTION
Refactor how events are typed by subclassing CustomEvent to prevent extending global and having to allow slow-types.