### PR TITLE
chore(core): reexport plugins

### DIFF
--- a/app/start.ts
+++ b/app/start.ts
@@ -1,23 +1,14 @@
 import type { Config } from "@radish/core";
-import { importmapPath, manifestPath, onDispose, startApp } from "@radish/core";
+import {
+  importmapPath,
+  manifestPath,
+  onDispose,
+  radishPlugins,
+  startApp,
+} from "@radish/core";
 import { fs, hmr, importmap, manifest, router } from "@radish/core/effects";
 import { dev } from "@radish/core/environment";
-import {
-  pluginBuild,
-  pluginConfig,
-  pluginEnv,
-  pluginFS,
-  pluginHMR,
-  pluginImportmap,
-  pluginManifest,
-  pluginRender,
-  pluginRouter,
-  pluginServer,
-  pluginStripTypes,
-  pluginWS,
-} from "@radish/core/plugins";
 import { Handler, handlerFor, HandlerScope } from "@radish/effect-system";
-import { pluginStdElements } from "@radish/std-elements";
 import { serveDir, UserAgent } from "@std/http";
 import { join } from "@std/path";
 
@@ -123,20 +114,8 @@ const scope = new HandlerScope(
       }),
     );
   }),
-  pluginStdElements,
-  pluginWS,
-  pluginServer,
-  pluginRouter,
-  pluginImportmap,
-  pluginRender,
   handleManifestLoad,
-  pluginManifest,
-  pluginHMR,
-  pluginStripTypes,
-  pluginBuild,
-  pluginEnv,
-  pluginConfig,
-  pluginFS,
+  ...radishPlugins,
 );
 onDispose(scope[Symbol.asyncDispose]);
 

--- a/core/mod.ts
+++ b/core/mod.ts
@@ -1,6 +1,38 @@
+import {
+  pluginBuild,
+  pluginConfig,
+  pluginEnv,
+  pluginFS,
+  pluginHMR,
+  pluginImportmap,
+  pluginManifest,
+  pluginRender,
+  pluginRouter,
+  pluginServer,
+  pluginStripTypes,
+  pluginWS,
+} from "@radish/core/plugins";
+import { pluginStdElements } from "@radish/std-elements";
+
 export { importmapPath } from "$effects/importmap.ts";
 export { manifestPath } from "$effects/manifest.ts";
 export { onDispose } from "./cleanup.ts";
 export * from "./conventions.ts";
 export { startApp } from "./start.ts";
 export type { Config, ManifestBase } from "./types.d.ts";
+
+export const radishPlugins = [
+  pluginStdElements,
+  pluginWS,
+  pluginServer,
+  pluginRouter,
+  pluginImportmap,
+  pluginRender,
+  pluginManifest,
+  pluginHMR,
+  pluginStripTypes,
+  pluginBuild,
+  pluginEnv,
+  pluginConfig,
+  pluginFS,
+];

--- a/init/template/base/start.ts
+++ b/init/template/base/start.ts
@@ -2,22 +2,8 @@ import type { Config } from "@radish/core";
 import { manifestPath, onDispose, startApp } from "@radish/core";
 import { hmr, manifest } from "@radish/core/effects";
 import { dev } from "@radish/core/environment";
-import {
-  pluginBuild,
-  pluginConfig,
-  pluginEnv,
-  pluginFS,
-  pluginHMR,
-  pluginImportmap,
-  pluginManifest,
-  pluginRender,
-  pluginRouter,
-  pluginServer,
-  pluginStripTypes,
-  pluginWS,
-} from "@radish/core/plugins";
+import { radishPlugins } from "@radish/core";
 import { handlerFor, HandlerScope } from "@radish/effect-system";
-import { pluginStdElements } from "@radish/std-elements";
 
 const config: Config = {
   importmap: {
@@ -68,22 +54,7 @@ const handleManifestLoad = handlerFor(manifest.load, async () => {
   }
 });
 
-const scope = new HandlerScope(
-  pluginStdElements,
-  pluginWS,
-  pluginServer,
-  pluginRouter,
-  pluginRender,
-  pluginImportmap,
-  handleManifestLoad,
-  pluginManifest,
-  pluginHMR,
-  pluginStripTypes,
-  pluginBuild,
-  pluginEnv,
-  pluginConfig,
-  pluginFS,
-);
+const scope = new HandlerScope(handleManifestLoad, ...radishPlugins);
 onDispose(scope[Symbol.asyncDispose]);
 
 await startApp(config);


### PR DESCRIPTION
Protects the init template from modifications when extending the plugins array